### PR TITLE
Update readme with basic content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# messaging-topology-operator
-RabbitMQ messaging topology operator
+# RabbitMQ Messaging Topology Kubernetes Operator
+
+Kubernetes operator to manage [RabbitMQ](https://www.rabbitmq.com/) messaging topologies within a RabbitMQ cluster deployed via the [RabbitMQ Cluster Kubernetes Operator](https://github.com/rabbitmq/cluster-operator/). This repository contains a [custom controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers) and [custom resource definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) enabling a declarative API for RabbitMQ messaging topologies.
+
+## Contributing
+
+This project follows the typical GitHub pull request model. Before starting any work, please either comment on an [existing issue](https://github.com/rabbitmq/messaging-topology-operator/issues), or file a new one.
+
+Please read [contribution guidelines](CONTRIBUTING.md) if you are interested in contributing to this project.
+
+## License
+
+[Licensed under the MPL](LICENSE.txt), same as RabbitMQ server and cluster operator.
+
+## Copyright
+
+Copyright 2021 VMware, Inc. All Rights Reserved.


### PR DESCRIPTION
## Summary Of Changes
This PR updates the README to have basic content about the purpose and function of the messaging topology operator, as well as linking to the license and contributing guides. 

This is in preparation for making the repo open source and publicly accessible.
