### PR TITLE
Do not requeue error if queue/exchanges are already deleted

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -110,3 +110,21 @@ func validateResponse(res *http.Response, err error) error {
 	}
 	return nil
 }
+
+// return a custom error if status code is 404
+// used in QueueReconciler.deleteQueue() and ExchangeReconcilier.deleteExchange()
+var NotFound = errors.New("not found")
+func validateResponseForDeletion(res *http.Response, err error) error {
+	if res.StatusCode == http.StatusNotFound {
+		return NotFound
+	}
+	if err != nil {
+		return err
+	}
+	if res.StatusCode >= http.StatusMultipleChoices {
+		body, _ := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		return fmt.Errorf("request failed with status code %d and body %q", res.StatusCode, body)
+	}
+	return nil
+}


### PR DESCRIPTION
This closes #26

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- ignore '404' NotFound error from server when deleting exchanges and queues
- autoDelete queue and exchanges could be autodeleted from server when the last consumer unsubscribe; should not requeue on error when the object is already gone
