### PR TITLE
Fix links to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ kubectl apply -f https://github.com/rabbitmq/messaging-topology-operator/release
 You can create RabbitMQ resources:
 
 1. [Queue](./docs/examples/queues)
-2. [Exchange](.docs/examples/exchanges)
-3. [Binding](.docs/examples/bindings)
-4. [User](.docs/examples/users)
-5. [Vhost](.docs/examples/vhosts)
+2. [Exchange](./docs/examples/exchanges)
+3. [Binding](./docs/examples/bindings)
+4. [User](./docs/examples/users)
+5. [Vhost](./docs/examples/vhosts)
 
 ## Contributing
 


### PR DESCRIPTION
Missing a slash to reference relative path to doc
