### PR TITLE
Set status.observedGeneration in all resources

### DIFF
--- a/api/v1alpha1/binding_types.go
+++ b/api/v1alpha1/binding_types.go
@@ -39,7 +39,10 @@ type BindingSpec struct {
 
 // BindingStatus defines the observed state of Binding
 type BindingStatus struct {
-	Conditions []Condition `json:"conditions,omitempty"`
+	// observedGeneration is the most recent successful generation observed for this Binding. It corresponds to the
+	// Binding's generation, which is updated on mutation by the API Server.
+	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/exchange_types.go
+++ b/api/v1alpha1/exchange_types.go
@@ -37,7 +37,10 @@ type ExchangeSpec struct {
 
 // ExchangeStatus defines the observed state of Exchange
 type ExchangeStatus struct {
-	Conditions []Condition `json:"conditions,omitempty"`
+	// observedGeneration is the most recent successful generation observed for this Exchange. It corresponds to the
+	// Exchange's generation, which is updated on mutation by the API Server.
+	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/policy_types.go
+++ b/api/v1alpha1/policy_types.go
@@ -39,7 +39,10 @@ type PolicySpec struct {
 
 // PolicyStatus defines the observed state of Policy
 type PolicyStatus struct {
-	Conditions []Condition `json:"conditions,omitempty"`
+	// observedGeneration is the most recent successful generation observed for this Policy. It corresponds to the
+	// Policy's generation, which is updated on mutation by the API Server.
+	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/queue_types.go
+++ b/api/v1alpha1/queue_types.go
@@ -50,7 +50,10 @@ type RabbitmqClusterReference struct {
 
 // QueueStatus defines the observed state of Queue
 type QueueStatus struct {
-	Conditions []Condition `json:"conditions,omitempty"`
+	// observedGeneration is the most recent successful generation observed for this Queue. It corresponds to the
+	// Queue's generation, which is updated on mutation by the API Server.
+	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -37,7 +37,10 @@ type UserSpec struct {
 
 // UserStatus defines the observed state of User.
 type UserStatus struct {
-	Conditions []Condition `json:"conditions,omitempty"`
+	// observedGeneration is the most recent successful generation observed for this User. It corresponds to the
+	// User's generation, which is updated on mutation by the API Server.
+	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
 	// Provides a reference to a Secret object containing the user credentials.
 	Credentials *corev1.LocalObjectReference `json:"credentials,omitempty"`
 }

--- a/api/v1alpha1/vhost_types.go
+++ b/api/v1alpha1/vhost_types.go
@@ -27,7 +27,10 @@ type VhostSpec struct {
 
 // VhostStatus defines the observed state of Vhost
 type VhostStatus struct {
-	Conditions []Condition `json:"conditions,omitempty"`
+	// observedGeneration is the most recent successful generation observed for this Vhost. It corresponds to the
+	// Vhost's generation, which is updated on mutation by the API Server.
+	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -98,6 +98,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Binding. It corresponds to the Binding's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -102,6 +102,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Exchange. It corresponds to the Exchange's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -112,6 +112,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Policy. It corresponds to the Policy's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -102,6 +102,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Queue. It corresponds to the Queue's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -120,6 +120,12 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this User. It corresponds to the User's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -86,6 +86,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Vhost. It corresponds to the Vhost's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/controllers/binding_controller.go
+++ b/controllers/binding_controller.go
@@ -66,16 +66,17 @@ func (r *BindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			return r.Status().Update(ctx, binding)
 		}); writerErr != nil {
-			logger.Error(writerErr, failedConditionsUpdate)
+			logger.Error(writerErr, failedStatusUpdate)
 		}
 		return ctrl.Result{}, err
 	}
 
 	binding.Status.Conditions = []topologyv1alpha1.Condition{topologyv1alpha1.Ready()}
+	binding.Status.ObservedGeneration = binding.GetGeneration()
 	if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, binding)
 	}); writerErr != nil {
-		logger.Error(writerErr, failedConditionsUpdate)
+		logger.Error(writerErr, failedStatusUpdate)
 	}
 	logger.Info("Finished reconciling")
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -2,7 +2,7 @@ package controllers
 
 // common error messages shared across controllers
 const (
-	failedConditionsUpdate     = "Failed to update status conditions"
+	failedStatusUpdate         = "Failed to update object status"
 	failedMarshalSpec          = "Failed to marshal spec"
 	failedGenerateRabbitClient = "Failed to generate http rabbitClient"
 )

--- a/controllers/exchange_controller.go
+++ b/controllers/exchange_controller.go
@@ -79,16 +79,17 @@ func (r *ExchangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			return r.Status().Update(ctx, exchange)
 		}); writerErr != nil {
-			logger.Error(writerErr, failedConditionsUpdate)
+			logger.Error(writerErr, failedStatusUpdate)
 		}
 		return ctrl.Result{}, err
 	}
 
 	exchange.Status.Conditions = []topologyv1alpha1.Condition{topologyv1alpha1.Ready()}
+	exchange.Status.ObservedGeneration = exchange.GetGeneration()
 	if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, exchange)
 	}); writerErr != nil {
-		logger.Error(writerErr, failedConditionsUpdate)
+		logger.Error(writerErr, failedStatusUpdate)
 	}
 	logger.Info("Finished reconciling")
 

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -79,16 +79,17 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			return r.Status().Update(ctx, policy)
 		}); writerErr != nil {
-			logger.Error(writerErr, failedConditionsUpdate)
+			logger.Error(writerErr, failedStatusUpdate)
 		}
 		return ctrl.Result{}, err
 	}
 
 	policy.Status.Conditions = []topologyv1alpha1.Condition{topologyv1alpha1.Ready()}
+	policy.Status.ObservedGeneration = policy.GetGeneration()
 	if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, policy)
 	}); writerErr != nil {
-		logger.Error(writerErr, failedConditionsUpdate)
+		logger.Error(writerErr, failedStatusUpdate)
 	}
 	logger.Info("Finished reconciling")
 

--- a/controllers/queue_controller.go
+++ b/controllers/queue_controller.go
@@ -85,16 +85,17 @@ func (r *QueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			return r.Status().Update(ctx, q)
 		}); writerErr != nil {
-			logger.Error(writerErr, failedConditionsUpdate)
+			logger.Error(writerErr, failedStatusUpdate)
 		}
 		return ctrl.Result{}, err
 	}
 
 	q.Status.Conditions = []topologyv1alpha1.Condition{topologyv1alpha1.Ready()}
+	q.Status.ObservedGeneration = q.GetGeneration()
 	if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, q)
 	}); writerErr != nil {
-		logger.Error(writerErr, failedConditionsUpdate)
+		logger.Error(writerErr, failedStatusUpdate)
 	}
 	logger.Info("Finished reconciling")
 

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -100,16 +100,17 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			return r.Status().Update(ctx, user)
 		}); writerErr != nil {
-			logger.Error(writerErr, failedConditionsUpdate)
+			logger.Error(writerErr, failedStatusUpdate)
 		}
 		return ctrl.Result{}, err
 	}
 
 	user.Status.Conditions = []topologyv1alpha1.Condition{topologyv1alpha1.Ready()}
+	user.Status.ObservedGeneration = user.GetGeneration()
 	if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, user)
 	}); writerErr != nil {
-		logger.Error(writerErr, failedConditionsUpdate)
+		logger.Error(writerErr, failedStatusUpdate)
 	}
 
 	logger.Info("Finished reconciling")

--- a/controllers/vhost_controller.go
+++ b/controllers/vhost_controller.go
@@ -71,16 +71,17 @@ func (r *VhostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 			return r.Status().Update(ctx, vhost)
 		}); writerErr != nil {
-			logger.Error(writerErr, failedConditionsUpdate)
+			logger.Error(writerErr, failedStatusUpdate)
 		}
 		return ctrl.Result{}, err
 	}
 
 	vhost.Status.Conditions = []topologyv1alpha1.Condition{topologyv1alpha1.Ready()}
+	vhost.Status.ObservedGeneration = vhost.GetGeneration()
 	if writerErr := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		return r.Status().Update(ctx, vhost)
 	}); writerErr != nil {
-		logger.Error(writerErr, failedConditionsUpdate)
+		logger.Error(writerErr, failedStatusUpdate)
 	}
 	logger.Info("Finished reconciling")
 

--- a/system_tests/binding_system_tests.go
+++ b/system_tests/binding_system_tests.go
@@ -121,5 +121,8 @@ var _ = Describe("Binding", func() {
 		Expect(readyCondition.Status).To(Equal(corev1.ConditionTrue))
 		Expect(readyCondition.Reason).To(Equal("SuccessfulCreateOrUpdate"))
 		Expect(readyCondition.LastTransitionTime).NotTo(Equal(metav1.Time{}))
+
+		By("setting status.observedGeneration")
+		Expect(updatedBinding.Status.ObservedGeneration).To(Equal(updatedBinding.GetGeneration()))
 	})
 })

--- a/system_tests/exchange_system_tests.go
+++ b/system_tests/exchange_system_tests.go
@@ -75,6 +75,9 @@ var _ = Describe("Exchange", func() {
 		Expect(readyCondition.Reason).To(Equal("SuccessfulCreateOrUpdate"))
 		Expect(readyCondition.LastTransitionTime).NotTo(Equal(metav1.Time{}))
 
+		By("setting status.observedGeneration")
+		Expect(updatedExchange.Status.ObservedGeneration).To(Equal(updatedExchange.GetGeneration()))
+
 		By("deleting exchange")
 		Expect(k8sClient.Delete(ctx, exchange)).To(Succeed())
 		var err error

--- a/system_tests/policy_system_tests.go
+++ b/system_tests/policy_system_tests.go
@@ -75,6 +75,9 @@ var _ = Describe("Policy", func() {
 		Expect(readyCondition.Reason).To(Equal("SuccessfulCreateOrUpdate"))
 		Expect(readyCondition.LastTransitionTime).NotTo(Equal(metav1.Time{}))
 
+		By("setting status.observedGeneration")
+		Expect(updatedPolicy.Status.ObservedGeneration).To(Equal(updatedPolicy.GetGeneration()))
+
 		By("updating policy")
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, policy)).To(Succeed())
 		policy.Spec.Definition = &runtime.RawExtension{

--- a/system_tests/queue_system_tests.go
+++ b/system_tests/queue_system_tests.go
@@ -75,6 +75,9 @@ var _ = Describe("Queue Controller", func() {
 		Expect(readyCondition.Reason).To(Equal("SuccessfulCreateOrUpdate"))
 		Expect(readyCondition.LastTransitionTime).NotTo(Equal(metav1.Time{}))
 
+		By("setting status.observedGeneration")
+		Expect(updatedQueue.Status.ObservedGeneration).To(Equal(updatedQueue.GetGeneration()))
+
 		By("deleting queue")
 		Expect(k8sClient.Delete(ctx, q)).To(Succeed())
 		var err error

--- a/system_tests/user_system_tests.go
+++ b/system_tests/user_system_tests.go
@@ -112,6 +112,9 @@ var _ = Describe("Users", func() {
 			Expect(readyCondition.Reason).To(Equal("SuccessfulCreateOrUpdate"))
 			Expect(readyCondition.LastTransitionTime).NotTo(Equal(metav1.Time{}))
 
+			By("setting status.observedGeneration")
+			Expect(updatedUser.Status.ObservedGeneration).To(Equal(updatedUser.GetGeneration()))
+
 			By("deleting user")
 			Expect(k8sClient.Delete(ctx, user)).To(Succeed())
 			Eventually(func() error {

--- a/system_tests/vhost_system_tests.go
+++ b/system_tests/vhost_system_tests.go
@@ -59,6 +59,9 @@ var _ = Describe("vhost", func() {
 		Expect(readyCondition.Reason).To(Equal("SuccessfulCreateOrUpdate"))
 		Expect(readyCondition.LastTransitionTime).NotTo(Equal(metav1.Time{}))
 
+		By("setting status.observedGeneration")
+		Expect(updatedVhost.Status.ObservedGeneration).To(Equal(updatedVhost.GetGeneration()))
+
 		By("deleting a vhost")
 		Expect(k8sClient.Delete(ctx, vhost)).To(Succeed())
 		var err error


### PR DESCRIPTION
This closes #43 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- Set status.observedGeneration in all resources: queues, exchanges, binding, queues, users and policies.
- Only set status.observedGeneration when the controller has successfully reconciled the version

## Additional Context

Added tests in system-tests
