### PR TITLE
Api docs

### DIFF
--- a/.github/workflows/publish-versioned-api-ref.yml
+++ b/.github/workflows/publish-versioned-api-ref.yml
@@ -1,0 +1,45 @@
+name: "Publish Versioned API Reference Wiki page"
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish-versioned-api-reference:
+    name: Publish Versioned API Reference Wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout operator codebase
+        uses: actions/checkout@v2
+        with:
+          path: messaging-topology-operator
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Checkout wiki codebase
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+      - name: Push to wiki
+        run: |
+          cd wiki
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "github-actions"
+          # Add the versioned API Reference to the Wiki
+          cp ../messaging-topology-operator/docs/api/rabbitmq.com.ref.asciidoc ./API_Reference_${{ steps.get_version.outputs.VERSION }}.asciidoc
+          # Regenerate the ordered list of API Reference docs for the sidebar
+          export REGENERATED_SIDEBAR="$(../messaging-topology-operator/hack/generate-ordered-api-reference-list.sh .)"
+          echo "$REGENERATED_SIDEBAR" > Wiki_Sidebar.md
+          git add ./API_Reference_${{ steps.get_version.outputs.VERSION }}.asciidoc
+          git add ./Wiki_Sidebar.md
+          git commit -m "Publish version ${{ steps.get_version.outputs.VERSION }} API Reference" && git push
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,action,eventName
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/update-latest-api-ref.yml
+++ b/.github/workflows/update-latest-api-ref.yml
@@ -1,0 +1,37 @@
+name: "Update Latest API Reference Wiki page"
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update-api-reference:
+    name: Update Latest API Reference Wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout operator codebase
+        uses: actions/checkout@v2
+        with:
+          path: messaging-topology-operator
+      - name: Checkout wiki codebase
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+      - name: Push to wiki
+        run: |
+          cd wiki
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "github-actions"
+          # Update the latest API Reference Doc
+          cp ../messaging-topology-operator/docs/api/rabbitmq.com.ref.asciidoc ./API_Reference.asciidoc
+          git add ./API_Reference.asciidoc
+          git diff-index --quiet HEAD || git commit -m "Update Latest API Reference" && git push
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,action,eventName
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,15 @@ deploy-rbac:
 manifests: install-tools
 	controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+# Generate API reference documentation
+api-reference:
+	crd-ref-docs \
+		--source-path ./api/v1alpha1 \
+		--config ./docs/api/autogen/config.yaml \
+		--templates-dir ./docs/api/autogen/templates \
+		--output-path ./docs/api/rabbitmq.com.ref.asciidoc \
+		--max-depth 30
+
 # Run go fmt against code
 fmt:
 	go fmt ./...
@@ -69,8 +78,8 @@ fmt:
 vet:
 	go vet ./...
 
-# Generate code
-generate: install-tools
+# Generate code & docs
+generate: install-tools api-reference
 	controller-gen object:headerFile="hack/NOTICE.go.txt" paths="./..."
 
 check-env-docker-credentials: check-env-registry-server

--- a/docs/api/autogen/config.yaml
+++ b/docs/api/autogen/config.yaml
@@ -1,0 +1,2 @@
+render:
+  kubernetesVersion: "1.20"

--- a/docs/api/autogen/templates/gv_details.tpl
+++ b/docs/api/autogen/templates/gv_details.tpl
@@ -1,0 +1,20 @@
+{{- define "gvDetails" -}}
+{{- $gv := . -}}
+[id="{{ asciidocGroupVersionID $gv | asciidocRenderAnchorID }}"]
+== {{ $gv.GroupVersionString }}
+
+{{ $gv.Doc }}
+
+{{- if $gv.Kinds  }}
+.Resource Types
+{{- range $gv.SortedKinds }}
+- {{ $gv.TypeForKind . | asciidocRenderTypeLink }}
+{{- end }}
+{{ end }}
+
+=== Definitions
+{{ range $gv.SortedTypes }}
+{{ template "type" . }}
+{{ end }}
+
+{{- end -}}

--- a/docs/api/autogen/templates/gv_list.tpl
+++ b/docs/api/autogen/templates/gv_list.tpl
@@ -1,0 +1,19 @@
+{{- define "gvList" -}}
+{{- $groupVersions := . -}}
+
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+= API Reference
+
+.Packages
+{{- range $groupVersions }}
+- {{ asciidocRenderGVLink . }}
+{{- end }}
+
+{{ range $groupVersions }}
+{{ template "gvDetails" . }}
+{{ end }}
+
+{{- end -}}

--- a/docs/api/autogen/templates/type.tpl
+++ b/docs/api/autogen/templates/type.tpl
@@ -1,0 +1,35 @@
+{{- define "type" -}}
+{{- $type := . -}}
+{{- if asciidocShouldRenderType $type -}}
+
+[id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
+==== {{ $type.Name  }} {{ if $type.IsAlias }}({{ asciidocRenderTypeLink $type.UnderlyingType  }}) {{ end }}
+
+{{ $type.Doc }}
+
+{{ if $type.References -}}
+.Appears In:
+****
+{{- range $type.SortedReferences }}
+- {{ asciidocRenderTypeLink . }}
+{{- end }}
+****
+{{- end }}
+
+{{ if $type.Members -}}
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+{{ if $type.GVK -}}
+| *`apiVersion`* __string__ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}`
+| *`kind`* __string__ | `{{ $type.GVK.Kind }}`
+{{ end -}}
+
+{{ range $type.Members -}}
+| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }}
+{{ end -}}
+|===
+{{ end -}}
+
+{{- end -}}
+{{- end -}}

--- a/docs/api/autogen/templates/type_members.tpl
+++ b/docs/api/autogen/templates/type_members.tpl
@@ -1,0 +1,8 @@
+{{- define "type_members" -}}
+{{- $field := . -}}
+{{- if eq $field.Name "metadata" -}}
+Refer to Kubernetes API documentation for fields of `metadata`.
+{{ else -}}
+{{ $field.Doc }}
+{{- end -}}
+{{- end -}}

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -1,0 +1,596 @@
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+= API Reference
+
+.Packages
+- xref:{anchor_prefix}-rabbitmq-com-v1alpha1[$$rabbitmq.com/v1alpha1$$]
+
+
+[id="{anchor_prefix}-rabbitmq-com-v1alpha1"]
+== rabbitmq.com/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the rabbitmq.com v1alpha1 API group
+
+.Resource Types
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-binding[$$Binding$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindinglist[$$BindingList$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchange[$$Exchange$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangelist[$$ExchangeList$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policy[$$Policy$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policylist[$$PolicyList$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queue[$$Queue$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuelist[$$QueueList$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-user[$$User$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userlist[$$UserList$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhost[$$Vhost$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhostlist[$$VhostList$$]
+
+
+=== Definitions
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-binding"]
+==== Binding 
+
+Binding is the Schema for the bindings API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindinglist[$$BindingList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `Binding`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindingspec[$$BindingSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindingstatus[$$BindingStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindinglist"]
+==== BindingList 
+
+BindingList contains a list of Binding
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `BindingList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-binding[$$Binding$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindingspec"]
+==== BindingSpec 
+
+BindingSpec defines the desired state of Binding
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-binding[$$Binding$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`vhost`* __string__ | Default to vhost '/'
+| *`source`* __string__ | 
+| *`destination`* __string__ | 
+| *`destinationType`* __string__ | 
+| *`routingKey`* __string__ | 
+| *`arguments`* __RawExtension__ | 
+| *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the binding will be created in. Required property.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindingstatus"]
+==== BindingStatus 
+
+BindingStatus defines the observed state of Binding
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-binding[$$Binding$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this Binding. It corresponds to the Binding's generation, which is updated on mutation by the API Server.
+| *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$] array__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition"]
+==== Condition 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindingstatus[$$BindingStatus$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangestatus[$$ExchangeStatus$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policystatus[$$PolicyStatus$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuestatus[$$QueueStatus$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userstatus[$$UserStatus$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhoststatus[$$VhostStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-conditiontype[$$ConditionType$$]__ | Type indicates the scope of RabbitmqCluster status addressed by the condition.
+| *`status`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core[$$ConditionStatus$$]__ | True, False, or Unknown
+| *`lastTransitionTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta[$$Time$$]__ | The last time this Condition type changed.
+| *`reason`* __string__ | One word, camel-case reason for current status of the condition.
+| *`message`* __string__ | Full text reason for current status of the condition.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-conditiontype"]
+==== ConditionType (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchange"]
+==== Exchange 
+
+Exchange is the Schema for the exchanges API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangelist[$$ExchangeList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `Exchange`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangespec[$$ExchangeSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangestatus[$$ExchangeStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangelist"]
+==== ExchangeList 
+
+ExchangeList contains a list of Exchange
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `ExchangeList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchange[$$Exchange$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangespec"]
+==== ExchangeSpec 
+
+ExchangeSpec defines the desired state of Exchange
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchange[$$Exchange$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | 
+| *`vhost`* __string__ | Default to vhost '/'
+| *`type`* __string__ | 
+| *`durable`* __boolean__ | 
+| *`autoDelete`* __boolean__ | 
+| *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | 
+| *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the exchange will be created in. Required property.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangestatus"]
+==== ExchangeStatus 
+
+ExchangeStatus defines the observed state of Exchange
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchange[$$Exchange$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this Exchange. It corresponds to the Exchange's generation, which is updated on mutation by the API Server.
+| *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policy"]
+==== Policy 
+
+Policy is the Schema for the policies API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policylist[$$PolicyList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `Policy`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policyspec[$$PolicySpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policystatus[$$PolicyStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policylist"]
+==== PolicyList 
+
+PolicyList contains a list of Policy
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `PolicyList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policy[$$Policy$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policyspec"]
+==== PolicySpec 
+
+PolicySpec defines the desired state of Policy https://www.rabbitmq.com/parameters.html#policies
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policy[$$Policy$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | 
+| *`vhost`* __string__ | Default to vhost '/'
+| *`pattern`* __string__ | Regular expression pattern used to match queues and exchanges, e.g. "^amq.". Required property.
+| *`applyTo`* __string__ | What this policy applies to: 'queues', 'exchanges', or 'all'. Default to 'all'.
+| *`priority`* __integer__ | Default to '0'. In the event that more than one policy can match a given exchange or queue, the policy with the greatest priority applies.
+| *`definition`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Policy definition. Required property.
+| *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the exchange will be created in. Required property.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policystatus"]
+==== PolicyStatus 
+
+PolicyStatus defines the observed state of Policy
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policy[$$Policy$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this Policy. It corresponds to the Policy's generation, which is updated on mutation by the API Server.
+| *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queue"]
+==== Queue 
+
+Queue is the Schema for the queues API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuelist[$$QueueList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `Queue`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuespec[$$QueueSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuestatus[$$QueueStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuelist"]
+==== QueueList 
+
+QueueList contains a list of Queue
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `QueueList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queue[$$Queue$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuespec"]
+==== QueueSpec 
+
+QueueSpec defines the desired state of Queue
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queue[$$Queue$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | Name of the queue; required property
+| *`vhost`* __string__ | Default to vhost '/'
+| *`type`* __string__ | 
+| *`durable`* __boolean__ | When set to false queues does not survive server restart
+| *`autoDelete`* __boolean__ | when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes
+| *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000
+| *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the queue will be created in. Required property.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuestatus"]
+==== QueueStatus 
+
+QueueStatus defines the observed state of Queue
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queue[$$Queue$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this Queue. It corresponds to the Queue's generation, which is updated on mutation by the API Server.
+| *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference"]
+==== RabbitmqClusterReference 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-bindingspec[$$BindingSpec$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-exchangespec[$$ExchangeSpec$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-policyspec[$$PolicySpec$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-queuespec[$$QueueSpec$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userspec[$$UserSpec$$]
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhostspec[$$VhostSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | 
+| *`namespace`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-user"]
+==== User 
+
+User is the Schema for the users API.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userlist[$$UserList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `User`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userspec[$$UserSpec$$]__ | Spec configures the desired state of the User object.
+| *`status`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userstatus[$$UserStatus$$]__ | Status exposes the observed state of the User object.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userlist"]
+==== UserList 
+
+UserList contains a list of Users.
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `UserList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-user[$$User$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userspec"]
+==== UserSpec 
+
+UserSpec defines the desired state of User.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-user[$$User$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`tags`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-usertag[$$UserTag$$] array__ | List of permissions tags to associate with the user. This determines the level of access to the RabbitMQ management UI granted to the user. Omitting this field will lead to a user than can still connect to the cluster through messaging protocols, but cannot perform any management actions. For more information, see https://www.rabbitmq.com/management.html#permissions.
+| *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the user will be created for. This cluster must exist for the User object to be created.
+| *`importCredentialsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Defines a Secret used to pre-define the username and password set for this User. User objects created with this field set will not have randomly-generated credentials, and will instead import the username/password values from this Secret. The Secret must contain the keys `username` and `password` in its Data field, or the import will fail. Note that this import only occurs at creation time, and is ignored once a password has been set on a User.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userstatus"]
+==== UserStatus 
+
+UserStatus defines the observed state of User.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-user[$$User$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this User. It corresponds to the User's generation, which is updated on mutation by the API Server.
+| *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$]__ | 
+| *`credentials`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Provides a reference to a Secret object containing the user credentials.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-usertag"]
+==== UserTag (string) 
+
+UserTag defines the level of access to the management UI allocated to the user. For more information, see https://www.rabbitmq.com/management.html#permissions.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-userspec[$$UserSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhost"]
+==== Vhost 
+
+Vhost is the Schema for the vhosts API
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhostlist[$$VhostList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `Vhost`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhostspec[$$VhostSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhoststatus[$$VhostStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhostlist"]
+==== VhostList 
+
+VhostList contains a list of Vhost
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `rabbitmq.com/v1alpha1`
+| *`kind`* __string__ | `VhostList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhost[$$Vhost$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhostspec"]
+==== VhostSpec 
+
+VhostSpec defines the desired state of Vhost
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhost[$$Vhost$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
+| *`tracing`* __boolean__ | 
+| *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the vhost will be created in. Required property.
+|===
+
+
+[id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhoststatus"]
+==== VhostStatus 
+
+VhostStatus defines the observed state of Vhost
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-vhost[$$Vhost$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this Vhost. It corresponds to the Vhost's generation, which is updated on mutation by the API Server.
+| *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1alpha1-condition[$$Condition$$]__ | 
+|===
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rabbitmq/messaging-topology-operator
 go 1.16
 
 require (
+	github.com/elastic/crd-ref-docs v0.0.7
 	github.com/go-logr/logr v0.4.0
 	github.com/michaelklishin/rabbit-hole/v2 v2.6.0
 	github.com/onsi/ginkgo v1.15.2

--- a/hack/generate-ordered-api-reference-list.sh
+++ b/hack/generate-ordered-api-reference-list.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+wikiDir=$1
+
+generateVersionedEntry() {
+  echo "* [$1](https://github.com/rabbitmq/messaging-topology-operator/wiki/API_Reference_$1)"
+}
+
+generateLatestEntry() {
+  echo "* [Latest](https://github.com/rabbitmq/messaging-topology-operator/wiki/API_Reference)"
+}
+
+lead='^<!--- BEGIN API REFERENCE LIST -->$'
+tail='^<!--- END API REFERENCE LIST -->$'
+
+unorderedlistfile="$(mktemp)"
+orderedlistfile="$(mktemp)"
+
+apiVersions="$(find "$wikiDir/API_Reference_*" -printf "%f\n" | sed -r 's/API_Reference_(v[0-9]+.[0-9]+.[0-9]+).asciidoc/\1/' | sort -Vr )"
+for version in $apiVersions
+do
+  generateVersionedEntry "$version" >> "$unorderedlistfile"
+done
+
+# Latest API version is a special case, that is always top of the list
+generateLatestEntry > "$orderedlistfile"
+cat "$unorderedlistfile" >> "$orderedlistfile"
+
+sed -e "/$lead/,/$tail/{ /$lead/{p; r $orderedlistfile
+}; /$tail/p; d }"  "$wikiDir/Wiki_Sidebar.md"

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,7 @@
 package tools
 
 import (
+	_ "github.com/elastic/crd-ref-docs"
 	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kustomize/kustomize/v3"


### PR DESCRIPTION
This closes #67

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes
Adds Make target to generate API docs
Adds github actions workflows to add docs to the wiki for the latest commit and releases.

