### PR TITLE
validation webhook for queues.rabbitmq.com and exchanges.rabbitmq.com

### DIFF
--- a/api/v1alpha1/exchange_types.go
+++ b/api/v1alpha1/exchange_types.go
@@ -12,6 +12,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ExchangeSpec defines the desired state of Exchange
@@ -62,6 +63,13 @@ type ExchangeList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Exchange `json:"items"`
+}
+
+func (e *Exchange) GroupResource() schema.GroupResource {
+	return schema.GroupResource{
+		Group:    e.GroupVersionKind().Group,
+		Resource: e.GroupVersionKind().Kind,
+	}
 }
 
 func init() {

--- a/api/v1alpha1/exchange_webhook.go
+++ b/api/v1alpha1/exchange_webhook.go
@@ -1,0 +1,88 @@
+package v1alpha1
+
+import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (r *Exchange) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-rabbitmq-com-v1alpha1-exchange,mutating=false,failurePolicy=fail,groups=rabbitmq.com,resources=exchanges,versions=v1alpha1,name=vexchange.kb.io,sideEffects=none,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Exchange{}
+
+// no validation on create
+func (e *Exchange) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// returns error type 'forbidden' for updates that the controller chooses to disallow: exchange name/vhost/rabbitmqClusterReference
+// returns error type 'invalid' for updates that will be rejected by rabbitmq server: exchange types/autoDelete/durable
+// exchange.spec.arguments can be updated
+func (e *Exchange) ValidateUpdate(old runtime.Object) error {
+	oldExchange, ok := old.(*Exchange)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected an exchange but got a %T", old))
+	}
+
+	var allErrs field.ErrorList
+	detailMsg := "updates on name, vhost, and rabbitmqClusterReference are all forbidden"
+	if e.Spec.Name != oldExchange.Spec.Name {
+		return apierrors.NewForbidden(e.GroupResource(), e.Name,
+			field.Forbidden(field.NewPath("spec", "name"), detailMsg))
+	}
+
+	if e.Spec.Vhost != oldExchange.Spec.Vhost {
+		return apierrors.NewForbidden(e.GroupResource(), e.Name,
+			field.Forbidden(field.NewPath("spec", "vhost"), detailMsg))
+	}
+
+	if e.Spec.RabbitmqClusterReference != oldExchange.Spec.RabbitmqClusterReference {
+		return apierrors.NewForbidden(e.GroupResource(), e.Name,
+			field.Forbidden(field.NewPath("spec", "rabbitmqClusterReference"), detailMsg))
+	}
+
+	if e.Spec.Type != oldExchange.Spec.Type {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "type"),
+			e.Spec.Type,
+			"exchange type cannot be updated",
+		))
+	}
+
+	if e.Spec.AutoDelete != oldExchange.Spec.AutoDelete {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "autoDelete"),
+			e.Spec.AutoDelete,
+			"autoDelete cannot be updated",
+		))
+	}
+
+	if e.Spec.Durable != oldExchange.Spec.Durable {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "durable"),
+			e.Spec.AutoDelete,
+			"durable cannot be updated",
+		))
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("Exchange").GroupKind(), e.Name, allErrs)
+}
+
+// no validation on delete
+func (e *Exchange) ValidateDelete() error {
+	return nil
+}

--- a/api/v1alpha1/exchange_webhook_test.go
+++ b/api/v1alpha1/exchange_webhook_test.go
@@ -1,0 +1,74 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("exchange webhook", func() {
+
+	var exchange = Exchange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "update-binding",
+		},
+		Spec: ExchangeSpec{
+			Name:       "test",
+			Vhost:      "/test",
+			Type:       "fanout",
+			Durable:    false,
+			AutoDelete: true,
+			RabbitmqClusterReference: RabbitmqClusterReference{
+				Name:      "some-cluster",
+				Namespace: "default",
+			},
+		},
+	}
+
+	It("does not allow updates on exchange name", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.Name = "new-name"
+		Expect(apierrors.IsForbidden(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("does not allow updates on vhost", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.Vhost = "/a-new-vhost"
+		Expect(apierrors.IsForbidden(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("does not allow updates on RabbitmqClusterReference", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.RabbitmqClusterReference = RabbitmqClusterReference{
+			Name:      "new-cluster",
+			Namespace: "default",
+		}
+		Expect(apierrors.IsForbidden(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("does not allow updates on exchange type", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.Type = "direct"
+		Expect(apierrors.IsInvalid(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("does not allow updates on durable", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.Durable = true
+		Expect(apierrors.IsInvalid(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("does not allow updates on autoDelete", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.AutoDelete = false
+		Expect(apierrors.IsInvalid(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("allows updates on arguments", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.Arguments = &runtime.RawExtension{Raw: []byte(`{"new":"new-value"}`)}
+		Expect(newExchange.ValidateUpdate(&exchange)).To(Succeed())
+	})
+})

--- a/api/v1alpha1/queue_types.go
+++ b/api/v1alpha1/queue_types.go
@@ -12,6 +12,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // using runtime.RawExtension to represent queue arguments
@@ -75,6 +76,13 @@ type QueueList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Queue `json:"items"`
+}
+
+func (q *Queue) GroupResource() schema.GroupResource {
+	return schema.GroupResource{
+		Group:    q.GroupVersionKind().Group,
+		Resource: q.GroupVersionKind().Kind,
+	}
 }
 
 func init() {

--- a/api/v1alpha1/queue_webhook.go
+++ b/api/v1alpha1/queue_webhook.go
@@ -1,0 +1,88 @@
+package v1alpha1
+
+import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (r *Queue) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-rabbitmq-com-v1alpha1-queue,mutating=false,failurePolicy=fail,groups=rabbitmq.com,resources=queues,versions=v1alpha1,name=vqueue.kb.io,sideEffects=none,admissionReviewVersions=v1sideEffects=none,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Queue{}
+
+// no validation on create
+func (q *Queue) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// returns error type 'forbidden' for updates that the controller chooses to disallow: queue name/vhost/rabbitmqClusterReference
+// returns error type 'invalid' for updates that will be rejected by rabbitmq server: queue types/autoDelete/durable
+// queue arguments not handled because implementation couldn't change
+func (q *Queue) ValidateUpdate(old runtime.Object) error {
+	oldQueue, ok := old.(*Queue)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a queue but got a %T", old))
+	}
+
+	var allErrs field.ErrorList
+	detailMsg := "updates on name, vhost, and rabbitmqClusterReference are all forbidden"
+	if q.Spec.Name != oldQueue.Spec.Name {
+		return apierrors.NewForbidden(q.GroupResource(), q.Name,
+			field.Forbidden(field.NewPath("spec", "name"), detailMsg))
+	}
+
+	if q.Spec.Vhost != oldQueue.Spec.Vhost {
+		return apierrors.NewForbidden(q.GroupResource(), q.Name,
+			field.Forbidden(field.NewPath("spec", "vhost"), detailMsg))
+	}
+
+	if q.Spec.RabbitmqClusterReference != oldQueue.Spec.RabbitmqClusterReference {
+		return apierrors.NewForbidden(q.GroupResource(), q.Name,
+			field.Forbidden(field.NewPath("spec", "rabbitmqClusterReference"), detailMsg))
+	}
+
+	if q.Spec.Type != oldQueue.Spec.Type {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "type"),
+			q.Spec.Type,
+			"queue type cannot be updated",
+		))
+	}
+
+	if q.Spec.AutoDelete != oldQueue.Spec.AutoDelete {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "autoDelete"),
+			q.Spec.AutoDelete,
+			"autoDelete cannot be updated",
+		))
+	}
+
+	if q.Spec.Durable != oldQueue.Spec.Durable {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "durable"),
+			q.Spec.AutoDelete,
+			"durable cannot be updated",
+		))
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("Queue").GroupKind(), q.Name, allErrs)
+}
+
+// no validation on delete
+func (q *Queue) ValidateDelete() error {
+	return nil
+}

--- a/api/v1alpha1/queue_webhook_test.go
+++ b/api/v1alpha1/queue_webhook_test.go
@@ -1,0 +1,67 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("queue webhook", func() {
+
+	var queue = Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "update-binding",
+		},
+		Spec: QueueSpec{
+			Name:       "test",
+			Vhost:      "/a-vhost",
+			Type:       "quorum",
+			Durable:    false,
+			AutoDelete: true,
+			RabbitmqClusterReference: RabbitmqClusterReference{
+				Name:      "some-cluster",
+				Namespace: "default",
+			},
+		},
+	}
+
+	It("does not allow updates on queue name", func() {
+		newQueue := queue.DeepCopy()
+		newQueue.Spec.Name = "new-name"
+		Expect(apierrors.IsForbidden(newQueue.ValidateUpdate(&queue))).To(BeTrue())
+	})
+
+	It("does not allow updates on vhost", func() {
+		newQueue := queue.DeepCopy()
+		newQueue.Spec.Vhost = "/new-vhost"
+		Expect(apierrors.IsForbidden(newQueue.ValidateUpdate(&queue))).To(BeTrue())
+	})
+
+	It("does not allow updates on RabbitmqClusterReference", func() {
+		newQueue := queue.DeepCopy()
+		newQueue.Spec.RabbitmqClusterReference = RabbitmqClusterReference{
+			Name:      "new-cluster",
+			Namespace: "default",
+		}
+		Expect(apierrors.IsForbidden(newQueue.ValidateUpdate(&queue))).To(BeTrue())
+	})
+
+	It("does not allow updates on queue type", func() {
+		newQueue := queue.DeepCopy()
+		newQueue.Spec.Type = "classic"
+		Expect(apierrors.IsInvalid(newQueue.ValidateUpdate(&queue))).To(BeTrue())
+	})
+
+	It("does not allow updates on durable", func() {
+		newQueue := queue.DeepCopy()
+		newQueue.Spec.Durable = true
+		Expect(apierrors.IsInvalid(newQueue.ValidateUpdate(&queue))).To(BeTrue())
+	})
+
+	It("does not allow updates on autoDelete", func() {
+		newQueue := queue.DeepCopy()
+		newQueue.Spec.AutoDelete = false
+		Expect(apierrors.IsInvalid(newQueue.ValidateUpdate(&queue))).To(BeTrue())
+	})
+})

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -13,10 +13,12 @@ resources:
 patchesStrategicMerge:
 - patches/webhook_in_bindings.yaml
 - patches/webhook_in_queues.yaml
+- patches/webhook_in_exchanges.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 - patches/cainjection_in_bindings.yaml
 - patches/cainjection_in_queues.yaml
+- patches/webhook_in_exchanges.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 configurations:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,9 +12,11 @@ resources:
 
 patchesStrategicMerge:
 - patches/webhook_in_bindings.yaml
+- patches/webhook_in_queues.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 - patches/cainjection_in_bindings.yaml
+- patches/cainjection_in_queues.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 configurations:

--- a/config/crd/patches/cainjection_in_exchanges.yaml
+++ b/config/crd/patches/cainjection_in_exchanges.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1alpha1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_queues.yaml
+++ b/config/crd/patches/cainjection_in_queues.yaml
@@ -1,6 +1,4 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-# CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1alpha1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_exchanges.yaml
+++ b/config/crd/patches/webhook_in_exchanges.yaml
@@ -1,17 +1,17 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1alpha1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: exchanges.rabbitmq.com
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_queues.yaml
+++ b/config/crd/patches/webhook_in_queues.yaml
@@ -1,17 +1,15 @@
-# The following patch enables conversion webhook for CRD
-# CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1alpha1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: queues.rabbitmq.com
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_users.yaml
+++ b/config/crd/patches/webhook_in_users.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -32,6 +32,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-rabbitmq-com-v1alpha1-exchange
+  failurePolicy: Fail
+  name: vexchange.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - exchanges
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-rabbitmq-com-v1alpha1-queue
   failurePolicy: Fail
   name: vqueue.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -26,3 +26,23 @@ webhooks:
     resources:
     - bindings
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-rabbitmq-com-v1alpha1-queue
+  failurePolicy: Fail
+  name: vqueue.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - queues
+  sideEffects: None

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 
-	rabbitmqcomv1alpha1 "github.com/rabbitmq/messaging-topology-operator/api/v1alpha1"
 	topologyv1alpha1 "github.com/rabbitmq/messaging-topology-operator/api/v1alpha1"
 	"github.com/rabbitmq/messaging-topology-operator/controllers"
 	// +kubebuilder:scaffold:imports
@@ -119,8 +118,12 @@ func main() {
 		log.Error(err, "unable to create controller", "controller", policyControllerName)
 		os.Exit(1)
 	}
-	if err = (&rabbitmqcomv1alpha1.Binding{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&topologyv1alpha1.Binding{}).SetupWebhookWithManager(mgr); err != nil {
 		log.Error(err, "unable to create webhook", "webhook", "Binding")
+		os.Exit(1)
+	}
+	if err = (&topologyv1alpha1.Queue{}).SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "Queue")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/main.go
+++ b/main.go
@@ -126,6 +126,10 @@ func main() {
 		log.Error(err, "unable to create webhook", "webhook", "Queue")
 		os.Exit(1)
 	}
+	if err = (&topologyv1alpha1.Exchange{}).SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "Exchange")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	log.Info("starting manager")


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- validation webhook for `queues.rabbitmq.com` and `exchanges.rabbitmq.com`
- validation webhook only checks for updates in the future. we should consider input validation for create in the future as well. 
- for queues, you get: 1) error type 'forbidden' for updates that the controller chooses to disallow: queue name/vhost/rabbitmqClusterReference; 2) error type 'invalid' for updates that will be rejected by rabbitmq server: queue types/autoDelete/durable. I chose to ignore queue.spec.arguments for now, since we might want to create policies under the hood in the future.
- for exchanges, you get: 1) error type 'forbidden' for updates that the controller chooses to disallow: queue name/vhost/rabbitmqClusterReference; 2) error type 'invalid' for updates that will be rejected by rabbitmq server: exchange types/autoDelete/durable; updates on exchanges arguments are accepted by the server

## Additional Context

Test coverage in unit and system tests.