### PR TITLE
validation webhooks for users, vhosts, and policies

### DIFF
--- a/api/v1alpha1/exchange_webhook_test.go
+++ b/api/v1alpha1/exchange_webhook_test.go
@@ -12,7 +12,7 @@ var _ = Describe("exchange webhook", func() {
 
 	var exchange = Exchange{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "update-binding",
+			Name: "test-exchange",
 		},
 		Spec: ExchangeSpec{
 			Name:       "test",

--- a/api/v1alpha1/policy_types.go
+++ b/api/v1alpha1/policy_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // PolicySpec defines the desired state of Policy
@@ -64,6 +65,13 @@ type PolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Policy `json:"items"`
+}
+
+func (p *Policy) GroupResource() schema.GroupResource {
+	return schema.GroupResource{
+		Group:    p.GroupVersionKind().Group,
+		Resource: p.GroupVersionKind().Kind,
+	}
 }
 
 func init() {

--- a/api/v1alpha1/policy_webhook.go
+++ b/api/v1alpha1/policy_webhook.go
@@ -1,0 +1,55 @@
+package v1alpha1
+
+import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (p *Policy) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(p).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-rabbitmq-com-v1alpha1-policy,mutating=false,failurePolicy=fail,groups=rabbitmq.com,resources=policies,versions=v1alpha1,name=vpolicy.kb.io,sideEffects=none,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Policy{}
+
+// no validation on create
+func (p *Policy) ValidateCreate() error {
+	return nil
+}
+
+// returns error type 'forbidden' for updates on policy name, vhost and rabbitmqClusterReference
+func (p *Policy) ValidateUpdate(old runtime.Object) error {
+	oldPolicy, ok := old.(*Policy)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a policy but got a %T", old))
+	}
+
+	detailMsg := "updates on name, vhost and rabbitmqClusterReference are all forbidden"
+	if p.Spec.Name != oldPolicy.Spec.Name {
+		return apierrors.NewForbidden(p.GroupResource(), p.Name,
+			field.Forbidden(field.NewPath("spec", "name"), detailMsg))
+	}
+
+	if p.Spec.Vhost != oldPolicy.Spec.Vhost {
+		return apierrors.NewForbidden(p.GroupResource(), p.Name,
+			field.Forbidden(field.NewPath("spec", "vhost"), detailMsg))
+	}
+
+	if p.Spec.RabbitmqClusterReference != oldPolicy.Spec.RabbitmqClusterReference {
+		return apierrors.NewForbidden(p.GroupResource(), p.Name,
+			field.Forbidden(field.NewPath("spec", "rabbitmqClusterReference"), detailMsg))
+	}
+	return nil
+}
+
+// no validation on delete
+func (p *Policy) ValidateDelete() error {
+	return nil
+}

--- a/api/v1alpha1/policy_webhook_test.go
+++ b/api/v1alpha1/policy_webhook_test.go
@@ -1,0 +1,73 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("policy webhook", func() {
+	var policy = Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: PolicySpec{
+			Name:     "test",
+			Vhost:    "/test",
+			Pattern:  "a-pattern",
+			ApplyTo:  "all",
+			Priority: 0,
+			RabbitmqClusterReference: RabbitmqClusterReference{
+				Name:      "a-cluster",
+				Namespace: "default",
+			},
+		},
+	}
+
+	It("does not allow updates on policy name", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.Name = "new-name"
+		Expect(apierrors.IsForbidden(newPolicy.ValidateUpdate(&policy))).To(BeTrue())
+	})
+
+	It("does not allow updates on vhost", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.Vhost = "new-vhost"
+		Expect(apierrors.IsForbidden(newPolicy.ValidateUpdate(&policy))).To(BeTrue())
+	})
+
+	It("does not allow updates on RabbitmqClusterReference", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.RabbitmqClusterReference = RabbitmqClusterReference{
+			Name:      "new-cluster",
+			Namespace: "default",
+		}
+		Expect(apierrors.IsForbidden(newPolicy.ValidateUpdate(&policy))).To(BeTrue())
+	})
+
+	It("allows updates on policy.spec.pattern", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.Pattern = "new-pattern"
+		Expect(newPolicy.ValidateUpdate(&policy)).To(Succeed())
+	})
+
+	It("allows updates on policy.spec.applyTo", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.ApplyTo = "queues"
+		Expect(newPolicy.ValidateUpdate(&policy)).To(Succeed())
+	})
+
+	It("allows updates on policy.spec.priority", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.Priority = 1000
+		Expect(newPolicy.ValidateUpdate(&policy)).To(Succeed())
+	})
+
+	It("allows updates on policy.spec.definition", func() {
+		newPolicy := policy.DeepCopy()
+		newPolicy.Spec.Definition = &runtime.RawExtension{Raw: []byte(`{"key":"new-definition-value"}`)}
+		Expect(newPolicy.ValidateUpdate(&policy)).To(Succeed())
+	})
+})

--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -12,6 +12,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // UserSpec defines the desired state of User.
@@ -72,6 +73,13 @@ type UserList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []User `json:"items"`
+}
+
+func (u *User) GroupResource() schema.GroupResource {
+	return schema.GroupResource{
+		Group:    u.GroupVersionKind().Group,
+		Resource: u.GroupVersionKind().Kind,
+	}
 }
 
 func init() {

--- a/api/v1alpha1/user_webhook.go
+++ b/api/v1alpha1/user_webhook.go
@@ -1,0 +1,45 @@
+package v1alpha1
+
+import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (u *User) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(u).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-rabbitmq-com-v1alpha1-user,mutating=false,failurePolicy=fail,groups=rabbitmq.com,resources=users,versions=v1alpha1,name=vuser.kb.io,sideEffects=none,admissionReviewVersions=v1
+
+var _ webhook.Validator = &User{}
+
+// no validation on create
+func (u *User) ValidateCreate() error {
+	return nil
+}
+
+// returns error type 'forbidden' for updates on rabbitmqClusterReference
+// user.spec.tags can be updated
+func (u *User) ValidateUpdate(old runtime.Object) error {
+	oldUser, ok := old.(*User)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a user but got a %T", old))
+	}
+
+	if u.Spec.RabbitmqClusterReference != oldUser.Spec.RabbitmqClusterReference {
+		return apierrors.NewForbidden(u.GroupResource(), u.Name,
+			field.Forbidden(field.NewPath("spec", "rabbitmqClusterReference"), "update on rabbitmqClusterReference is forbidden"))
+	}
+	return nil
+}
+
+// no validation on delete
+func (u *User) ValidateDelete() error {
+	return nil
+}

--- a/api/v1alpha1/vhost_types.go
+++ b/api/v1alpha1/vhost_types.go
@@ -11,6 +11,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // VhostSpec defines the desired state of Vhost
@@ -52,6 +53,13 @@ type VhostList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Vhost `json:"items"`
+}
+
+func (v *Vhost) GroupResource() schema.GroupResource {
+	return schema.GroupResource{
+		Group:    v.GroupVersionKind().Group,
+		Resource: v.GroupVersionKind().Kind,
+	}
 }
 
 func init() {

--- a/api/v1alpha1/vhost_webhook.go
+++ b/api/v1alpha1/vhost_webhook.go
@@ -1,0 +1,52 @@
+package v1alpha1
+
+import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (r *Vhost) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-rabbitmq-com-v1alpha1-vhost,mutating=false,failurePolicy=fail,groups=rabbitmq.com,resources=vhosts,versions=v1alpha1,name=vvhost.kb.io,sideEffects=none,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Vhost{}
+
+// no validation on create
+func (v *Vhost) ValidateCreate() error {
+	return nil
+}
+
+// returns error type 'forbidden' for updates on vhost name and rabbitmqClusterReference
+// vhost.spec.tracing can be updated
+func (v *Vhost) ValidateUpdate(old runtime.Object) error {
+	oldVhost, ok := old.(*Vhost)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a vhost but got a %T", old))
+	}
+
+	detailMsg := "updates on name and rabbitmqClusterReference are all forbidden"
+	if v.Spec.Name != oldVhost.Spec.Name {
+		return apierrors.NewForbidden(v.GroupResource(), v.Name,
+			field.Forbidden(field.NewPath("spec", "name"), detailMsg))
+	}
+
+	if v.Spec.RabbitmqClusterReference != oldVhost.Spec.RabbitmqClusterReference {
+		return apierrors.NewForbidden(v.GroupResource(), v.Name,
+			field.Forbidden(field.NewPath("spec", "rabbitmqClusterReference"), detailMsg))
+	}
+
+	return nil
+}
+
+// no validation on delete
+func (v *Vhost) ValidateDelete() error {
+	return nil
+}

--- a/api/v1alpha1/vhost_webhook_test.go
+++ b/api/v1alpha1/vhost_webhook_test.go
@@ -1,0 +1,46 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("vhost webhook", func() {
+
+	var vhost = Vhost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-vhost",
+		},
+		Spec: VhostSpec{
+			Name:    "test",
+			Tracing: false,
+			RabbitmqClusterReference: RabbitmqClusterReference{
+				Name:      "a-cluster",
+				Namespace: "default",
+			},
+		},
+	}
+
+	It("does not allow updates on vhost name", func() {
+		newVhost := vhost.DeepCopy()
+		newVhost.Spec.Name = "new-name"
+		Expect(apierrors.IsForbidden(newVhost.ValidateUpdate(&vhost))).To(BeTrue())
+	})
+
+	It("does not allow updates on RabbitmqClusterReference", func() {
+		newVhost := vhost.DeepCopy()
+		newVhost.Spec.RabbitmqClusterReference = RabbitmqClusterReference{
+			Name:      "new-cluster",
+			Namespace: "default",
+		}
+		Expect(apierrors.IsForbidden(newVhost.ValidateUpdate(&vhost))).To(BeTrue())
+	})
+
+	It("allows updates on vhost.spec.tracing", func() {
+		newVhost := vhost.DeepCopy()
+		newVhost.Spec.Tracing = true
+		Expect(newVhost.ValidateUpdate(&vhost)).To(Succeed())
+	})
+})

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -15,12 +15,14 @@ patchesStrategicMerge:
 - patches/webhook_in_queues.yaml
 - patches/webhook_in_exchanges.yaml
 - patches/webhook_in_vhosts.yaml
+- patches/webhook_in_policies.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 - patches/cainjection_in_bindings.yaml
 - patches/cainjection_in_queues.yaml
-- patches/webhook_in_exchanges.yaml
-- patches/webhook_in_vhosts.yaml
+- patches/cainjection_in_exchanges.yaml
+- patches/cainjection_in_vhosts.yaml
+- patches/cainjection_in_policies.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 configurations:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,6 +16,7 @@ patchesStrategicMerge:
 - patches/webhook_in_exchanges.yaml
 - patches/webhook_in_vhosts.yaml
 - patches/webhook_in_policies.yaml
+- patches/webhook_in_users.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 - patches/cainjection_in_bindings.yaml
@@ -23,6 +24,7 @@ patchesStrategicMerge:
 - patches/cainjection_in_exchanges.yaml
 - patches/cainjection_in_vhosts.yaml
 - patches/cainjection_in_policies.yaml
+- patches/cainjection_in_users.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 configurations:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -14,11 +14,13 @@ patchesStrategicMerge:
 - patches/webhook_in_bindings.yaml
 - patches/webhook_in_queues.yaml
 - patches/webhook_in_exchanges.yaml
+- patches/webhook_in_vhosts.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 - patches/cainjection_in_bindings.yaml
 - patches/cainjection_in_queues.yaml
 - patches/webhook_in_exchanges.yaml
+- patches/webhook_in_vhosts.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 configurations:

--- a/config/crd/patches/cainjection_in_policies.yaml
+++ b/config/crd/patches/cainjection_in_policies.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_users.yaml
+++ b/config/crd/patches/cainjection_in_users.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_vhosts.yaml
+++ b/config/crd/patches/cainjection_in_vhosts.yaml
@@ -1,6 +1,4 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-# CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_policies.yaml
+++ b/config/crd/patches/webhook_in_policies.yaml
@@ -1,17 +1,17 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: policies.rabbitmq.com
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_users.yaml
+++ b/config/crd/patches/webhook_in_users.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: users.rabbitmq.com

--- a/config/crd/patches/webhook_in_vhosts.yaml
+++ b/config/crd/patches/webhook_in_vhosts.yaml
@@ -1,17 +1,17 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vhosts.rabbitmq.com
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,6 +52,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-rabbitmq-com-v1alpha1-policy
+  failurePolicy: Fail
+  name: vpolicy.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - policies
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-rabbitmq-com-v1alpha1-queue
   failurePolicy: Fail
   name: vqueue.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -92,6 +92,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-rabbitmq-com-v1alpha1-user
+  failurePolicy: Fail
+  name: vuser.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - users
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-rabbitmq-com-v1alpha1-vhost
   failurePolicy: Fail
   name: vvhost.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -66,3 +66,23 @@ webhooks:
     resources:
     - queues
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-rabbitmq-com-v1alpha1-vhost
+  failurePolicy: Fail
+  name: vvhost.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vhosts
+  sideEffects: None

--- a/main.go
+++ b/main.go
@@ -134,6 +134,10 @@ func main() {
 		log.Error(err, "unable to create webhook", "webhook", "Vhost")
 		os.Exit(1)
 	}
+	if err = (&topologyv1alpha1.Policy{}).SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "Policy")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	log.Info("starting manager")

--- a/main.go
+++ b/main.go
@@ -130,6 +130,10 @@ func main() {
 		log.Error(err, "unable to create webhook", "webhook", "Exchange")
 		os.Exit(1)
 	}
+	if err = (&topologyv1alpha1.Vhost{}).SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "Vhost")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	log.Info("starting manager")

--- a/main.go
+++ b/main.go
@@ -138,6 +138,10 @@ func main() {
 		log.Error(err, "unable to create webhook", "webhook", "Policy")
 		os.Exit(1)
 	}
+	if err = (&topologyv1alpha1.User{}).SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "User")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	log.Info("starting manager")

--- a/system_tests/policy_system_tests.go
+++ b/system_tests/policy_system_tests.go
@@ -78,7 +78,13 @@ var _ = Describe("Policy", func() {
 		By("setting status.observedGeneration")
 		Expect(updatedPolicy.Status.ObservedGeneration).To(Equal(updatedPolicy.GetGeneration()))
 
-		By("updating policy")
+		By("not allowing updates on certain fields")
+		updateTest := topologyv1alpha1.Policy{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &updateTest)).To(Succeed())
+		updateTest.Spec.Vhost = "/a-new-vhost"
+		Expect(k8sClient.Update(ctx, &updateTest).Error()).To(ContainSubstring("spec.vhost: Forbidden: updates on name, vhost and rabbitmqClusterReference are all forbidden"))
+
+		By("updating policy definitions successfully")
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, policy)).To(Succeed())
 		policy.Spec.Definition = &runtime.RawExtension{
 			Raw: []byte(`{"ha-mode":"exactly",

--- a/system_tests/user_system_tests.go
+++ b/system_tests/user_system_tests.go
@@ -115,6 +115,12 @@ var _ = Describe("Users", func() {
 			By("setting status.observedGeneration")
 			Expect(updatedUser.Status.ObservedGeneration).To(Equal(updatedUser.GetGeneration()))
 
+			By("not allowing updates on certain fields")
+			updateTest := topologyv1alpha1.User{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &updateTest)).To(Succeed())
+			updateTest.Spec.RabbitmqClusterReference = topologyv1alpha1.RabbitmqClusterReference{Name: "a-new-cluster", Namespace: "default"}
+			Expect(k8sClient.Update(ctx, &updateTest).Error()).To(ContainSubstring("spec.rabbitmqClusterReference: Forbidden: update on rabbitmqClusterReference is forbidden"))
+
 			By("deleting user")
 			Expect(k8sClient.Delete(ctx, user)).To(Succeed())
 			Eventually(func() error {

--- a/system_tests/vhost_system_tests.go
+++ b/system_tests/vhost_system_tests.go
@@ -62,6 +62,12 @@ var _ = Describe("vhost", func() {
 		By("setting status.observedGeneration")
 		Expect(updatedVhost.Status.ObservedGeneration).To(Equal(updatedVhost.GetGeneration()))
 
+		By("not allowing updates on certain fields")
+		updateTest := topologyv1alpha1.Vhost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &updateTest)).To(Succeed())
+		updateTest.Spec.Name = "new-name"
+		Expect(k8sClient.Update(ctx, &updateTest).Error()).To(ContainSubstring("spec.name: Forbidden: updates on name and rabbitmqClusterReference are all forbidden"))
+
 		By("deleting a vhost")
 		Expect(k8sClient.Delete(ctx, vhost)).To(Succeed())
 		var err error


### PR DESCRIPTION
This closes #79 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- validation webhooks for `users.rabbitmq.com`, `vhosts.rabbitmq.com`, and `policies.rabbitmq.com`. 
- Updates on object name, vhost, and rabbitmqClusterReference will all result in a `Forbidden` error because allowing such updates means users can create multiple objects with updates, leaving previous object orphaned and cannot be deleted by the controller.
- Updates on users.spec.tags, vhosts.spec.tracing, and policies properties other than name, vhost, and rabbitmqClusterReference, are allowed by the controller and the RMQ server.

## Additional Context

Tested in unit tests and system tests. After this PR is approved and merged, I will start writing documentation on how to install the operator without cert-manager.