### PR TITLE
Use the correct status reference and stop generating client set all the time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ install-tools:
 	# This one just needs to be fetched and not installed, get & mod so it ends up in the right place.
 	# Note we grep it out above, and just do a go get & go mod for it.
 	go get -d k8s.io/code-generator
-	go mod vendor
 
 unit-tests: install-tools generate fmt vet manifests ## Run unit tests
 	ginkgo -r --randomizeAllSpecs api/ internal/
@@ -85,6 +84,8 @@ vet:
 # Generate code & docs
 generate: install-tools api-reference
 	controller-gen object:headerFile="hack/NOTICE.go.txt" paths="./..."
+
+generate-client-set:
 	./hack/update-codegen.sh
 
 check-env-docker-credentials: check-env-registry-server

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ generate: install-tools api-reference
 	controller-gen object:headerFile="hack/NOTICE.go.txt" paths="./..."
 
 generate-client-set:
+	# This one just needs to be fetched and not installed, get & mod so it ends up in the right place.
+	# Note we grep it out above, and just do a go get & go mod for it.
+	go get -d k8s.io/code-generator
+	go mod vendor
 	./hack/update-codegen.sh
 
 check-env-docker-credentials: check-env-registry-server

--- a/internal/rabbitmq_client_factory.go
+++ b/internal/rabbitmq_client_factory.go
@@ -120,8 +120,7 @@ func serviceSecretFromReference(ctx context.Context, c client.Client, rmq topolo
 	}
 
 	secret := &corev1.Secret{}
-	// TODO: use cluster.Status.Binding instead of cluster.Status.DefaultUser.SecretReference.Name after the PR exposes Status.Binding is released
-	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cluster.Status.DefaultUser.SecretReference.Name}, secret); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cluster.Status.Binding.Name}, secret); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/rabbitmq_client_factory_test.go
+++ b/internal/rabbitmq_client_factory_test.go
@@ -51,11 +51,10 @@ var _ = Describe("RabbitholeClientFactory", func() {
 				Namespace: "rabbitmq-system",
 			},
 			Status: rabbitmqv1beta1.RabbitmqClusterStatus{
+				Binding: &corev1.LocalObjectReference{
+					Name: "rmq-default-user-credentials",
+				},
 				DefaultUser: &rabbitmqv1beta1.RabbitmqClusterDefaultUser{
-					SecretReference: &rabbitmqv1beta1.RabbitmqClusterSecretReference{
-						Name:      "rmq-default-user-credentials",
-						Namespace: "rabbitmq-system",
-					},
 					ServiceReference: &rabbitmqv1beta1.RabbitmqClusterServiceReference{
 						Name:      "rmq-service",
 						Namespace: "rabbitmq-system",
@@ -96,7 +95,7 @@ var _ = Describe("RabbitholeClientFactory", func() {
 	AfterEach(func() {
 		fakeRabbitMQServer.Close()
 	})
-	It("generates a rabbithole client which makes sucessful requests to the RabbitMQ Server", func() {
+	It("generates a rabbithole client which makes successful requests to the RabbitMQ Server", func() {
 		generatedClient, err := internal.RabbitholeClientFactory(ctx, fakeClient, topology.RabbitmqClusterReference{Name: existingRabbitMQCluster.Name}, existingRabbitMQCluster.Namespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(generatedClient).NotTo(BeNil())

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,7 @@
 This closes #
 
 **Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
+**Note to contributors:** remember to re-generate client set if there are any API changes
 
 ## Summary Of Changes
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

- separate client set generation to its own make target and remove `go mod vendor` from installing tools
- add a line to remind contributors to re generate client set when create PRs
- use cluster.status.binding to get secret name instead of cluster.status.defaultUser.secretReference

## Additional Context
