### PR TITLE
add all to crd categories

### DIFF
--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: BindingList
     plural: bindings
     singular: binding
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: ExchangeList
     plural: exchanges
     singular: exchange
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: PermissionList
     plural: permissions
     singular: permission
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: PolicyList
     plural: policies
     singular: policy
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: QueueList
     plural: queues
     singular: queue
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: UserList
     plural: users
     singular: user
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: VhostList
     plural: vhosts
     singular: vhost
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1alpha2


### PR DESCRIPTION
This closes #106 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
Add CRDs to 'all' category so kubectl get all will display the rabbitmq resources.

## Additional Context
