### PR TITLE
Null check for RabbitmqCluster status

### DIFF
--- a/internal/rabbitmq_client_factory.go
+++ b/internal/rabbitmq_client_factory.go
@@ -119,6 +119,13 @@ func serviceSecretFromReference(ctx context.Context, c client.Client, rmq topolo
 		return nil, nil, err
 	}
 
+	if cluster.Status.Binding == nil {
+		return nil, nil, errors.New("no status.binding set")
+	}
+	if cluster.Status.DefaultUser == nil {
+		return nil, nil, errors.New("no status.defaultUser set")
+	}
+
 	secret := &corev1.Secret{}
 	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cluster.Status.Binding.Name}, secret); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Null check for RabbitmqCluster status (for malformed RabbitmqCluster or possible different versions of RabbitmqClusters)

## Additional Context
