### PR TITLE
Use kubebuilder marker to add all resources to all

### DIFF
--- a/api/v1alpha2/binding_types.go
+++ b/api/v1alpha2/binding_types.go
@@ -47,9 +47,10 @@ type BindingStatus struct {
 }
 
 // +genclient
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
 
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
+// +kubebuilder:subresource:status
 // Binding is the Schema for the bindings API
 type Binding struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha2/exchange_types.go
+++ b/api/v1alpha2/exchange_types.go
@@ -45,7 +45,9 @@ type ExchangeStatus struct {
 }
 
 // +genclient
+
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 // Exchange is the Schema for the exchanges API

--- a/api/v1alpha2/permission_types.go
+++ b/api/v1alpha2/permission_types.go
@@ -43,6 +43,7 @@ type PermissionStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 // Permission is the Schema for the permissions API

--- a/api/v1alpha2/policy_types.go
+++ b/api/v1alpha2/policy_types.go
@@ -47,7 +47,9 @@ type PolicyStatus struct {
 }
 
 // +genclient
+
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 // Policy is the Schema for the policies API

--- a/api/v1alpha2/queue_types.go
+++ b/api/v1alpha2/queue_types.go
@@ -56,7 +56,9 @@ type QueueStatus struct {
 }
 
 // +genclient
+
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 // Queue is the Schema for the queues API

--- a/api/v1alpha2/user_types.go
+++ b/api/v1alpha2/user_types.go
@@ -52,7 +52,9 @@ type UserStatus struct {
 type UserTag string
 
 // +genclient
+
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 // User is the Schema for the users API.

--- a/api/v1alpha2/vhost_types.go
+++ b/api/v1alpha2/vhost_types.go
@@ -35,7 +35,9 @@ type VhostStatus struct {
 }
 
 // +genclient
+
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 // Vhost is the Schema for the vhosts API

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: Binding
     listKind: BindingList
     plural: bindings
     singular: binding
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: Exchange
     listKind: ExchangeList
     plural: exchanges
     singular: exchange
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: Permission
     listKind: PermissionList
     plural: permissions
     singular: permission
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: Policy
     listKind: PolicyList
     plural: policies
     singular: policy
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: Queue
     listKind: QueueList
     plural: queues
     singular: queue
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: User
     listKind: UserList
     plural: users
     singular: user
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+    - all
     kind: Vhost
     listKind: VhostList
     plural: vhosts
     singular: vhost
-    categories:
-    - all
   scope: Namespaced
   versions:
   - name: v1alpha2


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Follow up from PR: https://github.com/rabbitmq/messaging-topology-operator/pull/107

`categories=all` is a kuberbuilder marker as well, this way it's generated by kuberbuilder

## Additional Context
