### PR TITLE
Example manifests are in docs/examples

### DIFF
--- a/config/samples/rabbitmq.com_v1alpha1_binding.yaml
+++ b/config/samples/rabbitmq.com_v1alpha1_binding.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: Binding
-metadata:
-  name: binding-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/rabbitmq.com_v1alpha1_exchange.yaml
+++ b/config/samples/rabbitmq.com_v1alpha1_exchange.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: Exchange
-metadata:
-  name: exchange-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/rabbitmq.com_v1alpha1_policy.yaml
+++ b/config/samples/rabbitmq.com_v1alpha1_policy.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: Policy
-metadata:
-  name: policy-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/rabbitmq.com_v1alpha1_queue.yaml
+++ b/config/samples/rabbitmq.com_v1alpha1_queue.yaml
@@ -1,4 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: Queue
-metadata:
-  name: test

--- a/config/samples/rabbitmq.com_v1alpha1_user.yaml
+++ b/config/samples/rabbitmq.com_v1alpha1_user.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: User
-metadata:
-  name: user-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/rabbitmq.com_v1alpha1_vhost.yaml
+++ b/config/samples/rabbitmq.com_v1alpha1_vhost.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: Vhost
-metadata:
-  name: vhost-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/rabbitmq.com_v1alpha2_permission.yaml
+++ b/config/samples/rabbitmq.com_v1alpha2_permission.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: Permission
-metadata:
-  name: permission-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/rabbitmq.com_v1alpha2_schemareplication.yaml
+++ b/config/samples/rabbitmq.com_v1alpha2_schemareplication.yaml
@@ -1,7 +1,0 @@
-apiVersion: rabbitmq.com/v1alpha2
-kind: SchemaReplication
-metadata:
-  name: schemareplication-sample
-spec:
-  # Add fields here
-  foo: bar


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Remove `config/samples/` because example manifests are in docs/examples.  Manifests in `config/samples/` are not maintained and outdated.

## Additional Context
