### PR TITLE
Update app.kubernetes.io/component labels on resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system
   labels:
     app.kubernetes.io/name: messaging-topology-operator
-    app.kubernetes.io/component: messaging-topology-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 spec:
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: messaging-topology-operator
-        app.kubernetes.io/component: messaging-topology-operator
+        app.kubernetes.io/component: rabbitmq-operator
         app.kubernetes.io/part-of: rabbitmq
     spec:
       serviceAccountName: messaging-topology-operator

--- a/config/namespace/namespace.yaml
+++ b/config/namespace/namespace.yaml
@@ -12,6 +12,6 @@ metadata:
   name: rabbitmq-system
   labels:
     app.kubernetes.io/name: rabbitmq-system
-    app.kubernetes.io/component: messaging-topology-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: leader-election-role
   labels:
     app.kubernetes.io/name: rabbitmq-cluster-operator
-    app.kubernetes.io/component: rabbitmq-cluster-operator
+    app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
 rules:
 - apiGroups:


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
This sets the component label on resources generated by kustomize to be consistent with the cluster operator.

## Additional Context
See also https://github.com/rabbitmq/cluster-operator/pull/671