### PR TITLE
Add CRD descriptions on fields that cannot be updated

### DIFF
--- a/api/v1beta1/binding_types.go
+++ b/api/v1beta1/binding_types.go
@@ -17,18 +17,23 @@ import (
 
 // BindingSpec defines the desired state of Binding
 type BindingSpec struct {
-	// Default to vhost '/'
+	// Default to vhost '/'; cannot be updated
 	// +kubebuilder:default:=/
 	Vhost string `json:"vhost,omitempty"`
+	// Cannot be updated
 	// +kubebuilder:validation:Optional
 	Source string `json:"source,omitempty"`
+	// Cannot be updated
 	// +kubebuilder:validation:Optional
 	Destination string `json:"destination,omitempty"`
+	// Cannot be updated
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=exchange;queue
 	DestinationType string `json:"destinationType,omitempty"`
+	// Cannot be updated
 	// +kubebuilder:validation:Optional
 	RoutingKey string `json:"routingKey,omitempty"`
+	// Cannot be updated
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Arguments *runtime.RawExtension `json:"arguments,omitempty"`

--- a/api/v1beta1/exchange_types.go
+++ b/api/v1beta1/exchange_types.go
@@ -17,15 +17,19 @@ import (
 
 // ExchangeSpec defines the desired state of Exchange
 type ExchangeSpec struct {
+	// Required property; cannot be updated
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
-	// Default to vhost '/'
+	// Default to vhost '/'; cannot be updated
 	// +kubebuilder:default:=/
 	Vhost string `json:"vhost,omitempty"`
+	// Cannot be updated
 	// +kubebuilder:validation:Enum=direct;fanout;headers;topic
 	// +kubebuilder:default:=direct
 	Type       string `json:"type,omitempty"`
+	// Cannot be updated
 	Durable    bool   `json:"durable,omitempty"`
+	// Cannot be updated
 	AutoDelete bool   `json:"autoDelete,omitempty"`
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/api/v1beta1/permission_types.go
+++ b/api/v1beta1/permission_types.go
@@ -7,10 +7,10 @@ import (
 
 // PermissionSpec defines the desired state of Permission
 type PermissionSpec struct {
-	// Name of an existing user; required property.
+	// Name of an existing user; required property; cannot be updated
 	// +kubebuilder:validation:Required
 	User string `json:"user"`
-	// Name of an existing vhost; required property.
+	// Name of an existing vhost; required property; cannot be updated
 	// +kubebuilder:validation:Required
 	Vhost string `json:"vhost"`
 	// Permissions to grant to the user in the specific vhost; required property.

--- a/api/v1beta1/policy_types.go
+++ b/api/v1beta1/policy_types.go
@@ -9,9 +9,10 @@ import (
 // PolicySpec defines the desired state of Policy
 // https://www.rabbitmq.com/parameters.html#policies
 type PolicySpec struct {
+	// Required property; cannot be updated
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
-	// Default to vhost '/'
+	// Default to vhost '/'; cannot be updated
 	// +kubebuilder:default:=/
 	Vhost string `json:"vhost,omitempty"`
 	// Regular expression pattern used to match queues and exchanges, e.g. "^amq.".

--- a/api/v1beta1/queue_types.go
+++ b/api/v1beta1/queue_types.go
@@ -43,6 +43,7 @@ type QueueSpec struct {
 }
 
 type RabbitmqClusterReference struct {
+	// Cannot be updated
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 }

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -39,11 +39,14 @@ spec:
             description: BindingSpec defines the desired state of Binding
             properties:
               arguments:
+                description: Cannot be updated
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               destination:
+                description: Cannot be updated
                 type: string
               destinationType:
+                description: Cannot be updated
                 enum:
                 - exchange
                 - queue
@@ -53,17 +56,20 @@ spec:
                   be created in. Required property.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name
                 type: object
               routingKey:
+                description: Cannot be updated
                 type: string
               source:
+                description: Cannot be updated
                 type: string
               vhost:
                 default: /
-                description: Default to vhost '/'
+                description: Default to vhost '/'; cannot be updated
                 type: string
             required:
             - rabbitmqClusterReference

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -42,22 +42,27 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               autoDelete:
+                description: Cannot be updated
                 type: boolean
               durable:
+                description: Cannot be updated
                 type: boolean
               name:
+                description: Required property; cannot be updated
                 type: string
               rabbitmqClusterReference:
                 description: Reference to the RabbitmqCluster that the exchange will
                   be created in. Required property.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name
                 type: object
               type:
                 default: direct
+                description: Cannot be updated
                 enum:
                 - direct
                 - fanout
@@ -66,7 +71,7 @@ spec:
                 type: string
               vhost:
                 default: /
-                description: Default to vhost '/'
+                description: Default to vhost '/'; cannot be updated
                 type: string
             required:
             - name

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -54,15 +54,18 @@ spec:
                   user and vhost are. Required property.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name
                 type: object
               user:
-                description: Name of an existing user; required property.
+                description: Name of an existing user; required property; cannot be
+                  updated
                 type: string
               vhost:
-                description: Name of an existing vhost; required property.
+                description: Name of an existing vhost; required property; cannot
+                  be updated
                 type: string
             required:
             - permissions

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -52,6 +52,7 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               name:
+                description: Required property; cannot be updated
                 type: string
               pattern:
                 description: Regular expression pattern used to match queues and exchanges,
@@ -68,13 +69,14 @@ spec:
                   be created in. Required property.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name
                 type: object
               vhost:
                 default: /
-                description: Default to vhost '/'
+                description: Default to vhost '/'; cannot be updated
                 type: string
             required:
             - definition

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -58,6 +58,7 @@ spec:
                   be created in. Required property.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -43,6 +43,7 @@ spec:
                   would be set for. Must be an existing cluster.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -57,6 +57,7 @@ spec:
                   created for. This cluster must exist for the User object to be created.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -46,6 +46,7 @@ spec:
                   be created in. Required property.
                 properties:
                   name:
+                    description: Cannot be updated
                     type: string
                 required:
                 - name

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -89,12 +89,12 @@ BindingSpec defines the desired state of Binding
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`vhost`* __string__ | Default to vhost '/'
-| *`source`* __string__ | 
-| *`destination`* __string__ | 
-| *`destinationType`* __string__ | 
-| *`routingKey`* __string__ | 
-| *`arguments`* __RawExtension__ | 
+| *`vhost`* __string__ | Default to vhost '/'; cannot be updated
+| *`source`* __string__ | Cannot be updated
+| *`destination`* __string__ | Cannot be updated
+| *`destinationType`* __string__ | Cannot be updated
+| *`routingKey`* __string__ | Cannot be updated
+| *`arguments`* __RawExtension__ | Cannot be updated
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the binding will be created in. Required property.
 |===
 
@@ -212,11 +212,11 @@ ExchangeSpec defines the desired state of Exchange
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | 
-| *`vhost`* __string__ | Default to vhost '/'
-| *`type`* __string__ | 
-| *`durable`* __boolean__ | 
-| *`autoDelete`* __boolean__ | 
+| *`name`* __string__ | Required property; cannot be updated
+| *`vhost`* __string__ | Default to vhost '/'; cannot be updated
+| *`type`* __string__ | Cannot be updated
+| *`durable`* __boolean__ | Cannot be updated
+| *`autoDelete`* __boolean__ | Cannot be updated
 | *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | 
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the exchange will be created in. Required property.
 |===
@@ -295,8 +295,8 @@ PermissionSpec defines the desired state of Permission
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`user`* __string__ | Name of an existing user; required property.
-| *`vhost`* __string__ | Name of an existing vhost; required property.
+| *`user`* __string__ | Name of an existing user; required property; cannot be updated
+| *`vhost`* __string__ | Name of an existing vhost; required property; cannot be updated
 | *`permissions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-vhostpermissions[$$VhostPermissions$$]__ | Permissions to grant to the user in the specific vhost; required property. See RabbitMQ doc for more information: https://www.rabbitmq.com/access-control.html#user-management
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that both the provided user and vhost are. Required property.
 |===
@@ -375,8 +375,8 @@ PolicySpec defines the desired state of Policy https://www.rabbitmq.com/paramete
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | 
-| *`vhost`* __string__ | Default to vhost '/'
+| *`name`* __string__ | Required property; cannot be updated
+| *`vhost`* __string__ | Default to vhost '/'; cannot be updated
 | *`pattern`* __string__ | Regular expression pattern used to match queues and exchanges, e.g. "^amq.". Required property.
 | *`applyTo`* __string__ | What this policy applies to: 'queues', 'exchanges', or 'all'. Default to 'all'.
 | *`priority`* __integer__ | Default to '0'. In the event that more than one policy can match a given exchange or queue, the policy with the greatest priority applies.
@@ -506,7 +506,7 @@ QueueStatus defines the observed state of Queue
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | 
+| *`name`* __string__ | Cannot be updated
 |===
 
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

As part of the effort of adding documentation for topology operator in rabbitmq.com (https://github.com/rabbitmq/rabbitmq-website/pull/1182), I realized that we are not documenting which fields cannot be updated in any CRDs api description. This PR adds description to all CRDs fields that cannot be updated.

## Additional Context
