### PR TITLE
Add update validation webhook for Shovel

### DIFF
--- a/api/v1beta1/shovel_types.go
+++ b/api/v1beta1/shovel_types.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ShovelSpec defines the desired state of Shovel
@@ -78,6 +79,13 @@ type ShovelList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Shovel `json:"items"`
+}
+
+func (s *Shovel) GroupResource() schema.GroupResource {
+	return schema.GroupResource{
+		Group:    s.GroupVersionKind().Group,
+		Resource: s.GroupVersionKind().Kind,
+	}
 }
 
 func init() {

--- a/api/v1beta1/shovel_webhook.go
+++ b/api/v1beta1/shovel_webhook.go
@@ -1,0 +1,54 @@
+package v1beta1
+
+import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (s *Shovel) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(s).
+		Complete()
+}
+// +kubebuilder:webhook:verbs=create;update,path=/validate-rabbitmq-com-v1beta1-shovel,mutating=false,failurePolicy=fail,groups=rabbitmq.com,resources=shovels,versions=v1beta1,name=vshovel.kb.io,sideEffects=none,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Shovel{}
+
+// no validation on create
+func (s *Shovel) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (s *Shovel) ValidateUpdate(old runtime.Object) error {
+	oldShovel, ok := old.(*Shovel)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a shovel but got a %T", oldShovel))
+	}
+
+	detailMsg := "updates on name, vhost and rabbitmqClusterReference are all forbidden"
+	if s.Spec.Name != oldShovel.Spec.Name {
+		return apierrors.NewForbidden(s.GroupResource(), s.Name,
+			field.Forbidden(field.NewPath("spec", "name"), detailMsg))
+	}
+
+	if s.Spec.Vhost != oldShovel.Spec.Vhost {
+		return apierrors.NewForbidden(s.GroupResource(), s.Name,
+			field.Forbidden(field.NewPath("spec", "vhost"), detailMsg))
+	}
+
+	if s.Spec.RabbitmqClusterReference != oldShovel.Spec.RabbitmqClusterReference {
+		return apierrors.NewForbidden(s.GroupResource(), s.Name,
+			field.Forbidden(field.NewPath("spec", "rabbitmqClusterReference"), detailMsg))
+	}
+	return nil
+}
+
+// no validation on delete
+func (s *Shovel) ValidateDelete() error {
+	return nil
+}

--- a/api/v1beta1/shovel_webhook_test.go
+++ b/api/v1beta1/shovel_webhook_test.go
@@ -1,0 +1,212 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("shovel webhook", func() {
+	var shovel = Shovel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: ShovelSpec{
+			Name:  "test-upstream",
+			Vhost: "/a-vhost",
+			UriSecret: &corev1.LocalObjectReference{
+				Name: "a-secret",
+			},
+			AckMode:                          "no-ack",
+			AddForwardHeaders:                true,
+			DeleteAfter:                      "never",
+			DestinationAddForwardHeaders:     true,
+			DestinationAddTimestampHeader:    true,
+			DestinationAddress:               "myQueue",
+			DestinationApplicationProperties: "a-property",
+			DestinationExchange:              "an-exchange",
+			DestinationExchangeKey:           "a-key",
+			DestinationProperties:            "a-property",
+			DestinationProtocol:              "amqp091",
+			DestinationPublishProperties:     "a-property",
+			DestinationQueue:                 "a-queue",
+			PrefetchCount:                    10,
+			ReconnectDelay:                   10,
+			SourceAddress:                    "myQueue",
+			SourceDeleteAfter:                "never",
+			SourceExchange:                   "an-exchange",
+			SourceExchangeKey:                "a-key",
+			SourcePrefetchCount:              10,
+			SourceProtocol:                   "amqp091",
+			SourceQueue:                      "a-queue",
+			RabbitmqClusterReference: RabbitmqClusterReference{
+				Name: "a-cluster",
+			},
+		},
+	}
+
+	It("does not allow updates on name", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.Name = "another-shovel"
+		Expect(apierrors.IsForbidden(newShovel.ValidateUpdate(&shovel))).To(BeTrue())
+	})
+
+	It("does not allow updates on vhost", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.Vhost = "another-vhost"
+		Expect(apierrors.IsForbidden(newShovel.ValidateUpdate(&shovel))).To(BeTrue())
+	})
+
+	It("does not allow updates on RabbitmqClusterReference", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.RabbitmqClusterReference = RabbitmqClusterReference{
+			Name: "another-cluster",
+		}
+		Expect(apierrors.IsForbidden(newShovel.ValidateUpdate(&shovel))).To(BeTrue())
+	})
+
+	It("allows updates on shovel.spec.uriSecret", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.UriSecret = &corev1.LocalObjectReference{Name: "another-secret"}
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on AckMode", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.AckMode = "on-confirm"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on AddForwardHeaders", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.AddForwardHeaders = false
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DeleteAfter", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DeleteAfter = "100"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on AddForwardHeaders", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.AddForwardHeaders = false
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationAddForwardHeaders", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationAddForwardHeaders = false
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationAddTimestampHeader", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationAddTimestampHeader = false
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationAddress", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DeleteAfter = "another"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationApplicationProperties", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationApplicationProperties = "new-property"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationExchange", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationExchange = "new-exchange"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationExchangeKey", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationExchangeKey = "new-key"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationProperties", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationProperties = "new"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+	It("allows updates on DestinationProtocol", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationProtocol = "new"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationPublishProperties", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationPublishProperties = "new-property"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on DestinationQueue", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.DestinationQueue = "another-queue"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on shovel.spec.PrefetchCount", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.PrefetchCount = 20
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on shovel.spec.reconnectDelay", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.PrefetchCount = 10000
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourceAddress", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourceAddress = "another-queue"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourceDeleteAfter", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourceDeleteAfter = "100"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourceExchange", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourceExchange = "another-exchange"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourceExchangeKey", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourceExchangeKey = "another-key"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourcePrefetchCount", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourcePrefetchCount = 50
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourceProtocol", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourceProtocol = "another-protocol"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+
+	It("allows updates on SourceQueue", func() {
+		newShovel := shovel.DeepCopy()
+		newShovel.Spec.SourceQueue = "another-queue"
+		Expect(newShovel.ValidateUpdate(&shovel)).To(Succeed())
+	})
+})

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -152,6 +152,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-rabbitmq-com-v1beta1-shovel
+  failurePolicy: Fail
+  name: vshovel.kb.io
+  rules:
+  - apiGroups:
+    - rabbitmq.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - shovels
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-rabbitmq-com-v1beta1-user
   failurePolicy: Fail
   name: vuser.kb.io

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 
 	rabbitmqv1beta1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 
-	rabbitmqcomv1beta1 "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
 	topology "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
 	"github.com/rabbitmq/messaging-topology-operator/controllers"
 	"github.com/rabbitmq/messaging-topology-operator/internal"
@@ -38,7 +37,6 @@ func init() {
 	_ = rabbitmqv1beta1.AddToScheme(scheme)
 
 	_ = topology.AddToScheme(scheme)
-	_ = rabbitmqcomv1beta1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -62,7 +60,7 @@ func main() {
 
 	if err = (&controllers.QueueReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Queue"),
+		Log:                   ctrl.Log.WithName(controllers.QueueControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.QueueControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -72,7 +70,7 @@ func main() {
 	}
 	if err = (&controllers.ExchangeReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Exchange"),
+		Log:                   ctrl.Log.WithName(controllers.ExchangeControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.ExchangeControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -82,7 +80,7 @@ func main() {
 	}
 	if err = (&controllers.BindingReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Binding"),
+		Log:                   ctrl.Log.WithName(controllers.BindingControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.BindingControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -92,7 +90,7 @@ func main() {
 	}
 	if err = (&controllers.UserReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("User"),
+		Log:                   ctrl.Log.WithName(controllers.UserControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.UserControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -102,7 +100,7 @@ func main() {
 	}
 	if err = (&controllers.VhostReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Vhost"),
+		Log:                   ctrl.Log.WithName(controllers.VhostControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.VhostControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -112,7 +110,7 @@ func main() {
 	}
 	if err = (&controllers.PolicyReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Policy"),
+		Log:                   ctrl.Log.WithName(controllers.PolicyControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.PolicyControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -122,7 +120,7 @@ func main() {
 	}
 	if err = (&controllers.PermissionReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Permission"),
+		Log:                   ctrl.Log.WithName(controllers.PermissionControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.PermissionControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -132,7 +130,7 @@ func main() {
 	}
 	if err = (&controllers.SchemaReplicationReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("SchemaReplication"),
+		Log:                   ctrl.Log.WithName(controllers.SchemaReplicationControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.SchemaReplicationControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -142,7 +140,7 @@ func main() {
 	}
 	if err = (&controllers.FederationReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Federation"),
+		Log:                   ctrl.Log.WithName(controllers.FederationControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.FederationControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -152,7 +150,7 @@ func main() {
 	}
 	if err = (&controllers.ShovelReconciler{
 		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("Shovel"),
+		Log:                   ctrl.Log.WithName(controllers.ShovelControllerName),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.ShovelControllerName),
 		RabbitmqClientFactory: internal.RabbitholeClientFactory,
@@ -197,7 +195,10 @@ func main() {
 		log.Error(err, "unable to create webhook", "webhook", "Federation")
 		os.Exit(1)
 	}
-
+	if err = (&topology.Shovel{}).SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "Shovel")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	log.Info("starting manager")


### PR DESCRIPTION
Follow up to PR https://github.com/rabbitmq/messaging-topology-operator/pull/152

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Add webhook for shovel to prevent updates on name, vhost and RabbitmqClusterReference

## Additional Context
