### PR TITLE
Shovel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can create RabbitMQ resources:
 6. [Policy](./docs/examples/policies)
 7. [Permissions](./docs/examples/permissions)
 8. [Federations](./docs/examples/federations)
+9. [Shovels](./docs/examples/shovels)
 
 ## Documentation
 

--- a/docs/examples/federations/README.md
+++ b/docs/examples/federations/README.md
@@ -3,7 +3,7 @@
 In this example, we will create federation between exchanges from two different vhosts in the same RabbitmqCluster.
 
 Before creating any topology objects with Messaging Topology Operator, please deploy a RabbitmqCluster named `example-rabbit`, or any name you see fit.
-You can pick any RabbitmqCluster example from the [cluster operator repo](https://github.com/rabbitmq/cluster-operator/blob/main/docs/examples).
+You will need to enable the `rabbitmq_federation` plugin and here is an example from the [cluster operator repo](https://github.com/rabbitmq/cluster-operator/blob/main/docs/examples/plugins/rabbitmq.yaml) about enabling additional plugins.
 
 After the RabbitMQ cluster is successfully created, you need to get username and password of the default user for this RabbitMQ cluster:
 

--- a/docs/examples/shovels/README.md
+++ b/docs/examples/shovels/README.md
@@ -1,0 +1,27 @@
+# Shovel Example
+
+In this example, we will declare a dynamic Shovel that moves messages from a clasic queue to a quorum queue in the same RabbitmqCluster.
+
+Before creating any topology objects with Messaging Topology Operator, please deploy a RabbitmqCluster named `example-rabbit`, or any name you see fit.
+You can pick any RabbitmqCluster example from the [cluster operator repo](https://github.com/rabbitmq/cluster-operator/blob/main/docs/examples).
+
+After the RabbitMQ cluster is successfully created, you need to get username and password of the default user for this RabbitMQ cluster:
+
+```bash
+kubectl get secret example-rabbit-default-user -o jsonpath='{.data.username}' | base64 --decode
+kubectl get secret example-rabbit-user -o jsonpath='{.data.password}' | base64 --decode
+```
+Save the username and password, because we need both later to construct the source and destination URI.
+
+This example includes (please create in order):
+
+1. two vhosts: 'source' and 'destination'
+1. a Kubernetes secret 'shovel-secret' containing the shovel source and destination URIs
+1. a classic queue 'source-queue' in vhost 'source' vhost
+1. a quorum queue 'destination-queue' in vhost 'destination'
+1. shovel 'shovel-example' between queue 'source-queue' and queue 'destination-queue'
+
+After all topology objects are created, messages in 'source queue'
+will be moved into 'destination-queue'.
+
+Learn [more about RabbitMQ Dynamic Shovel](https://www.rabbitmq.com/shovel-dynamic.html).

--- a/docs/examples/shovels/README.md
+++ b/docs/examples/shovels/README.md
@@ -2,8 +2,7 @@
 
 In this example, we will declare a dynamic Shovel that moves messages from a clasic queue to a quorum queue in the same RabbitmqCluster.
 
-Before creating any topology objects with Messaging Topology Operator, please deploy a RabbitmqCluster named `example-rabbit`, or any name you see fit.
-You can pick any RabbitmqCluster example from the [cluster operator repo](https://github.com/rabbitmq/cluster-operator/blob/main/docs/examples).
+Before creating any topology objects with Messaging Topology Operator, please deploy a RabbitmqCluster named `example-rabbit`, or any name you see fit. You will need to enable the `rabbitmq_shovel` plugin and here is an example from the [cluster operator repo](https://github.com/rabbitmq/cluster-operator/blob/main/docs/examples/plugins/rabbitmq.yaml) about enabling additional plugins.
 
 After the RabbitMQ cluster is successfully created, you need to get username and password of the default user for this RabbitMQ cluster:
 

--- a/docs/examples/shovels/queues.yaml
+++ b/docs/examples/shovels/queues.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: source-queue
+  namespace: rabbitmq-system
+spec:
+  name: source-queue
+  vhost: "source"
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: example-rabbit
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: destination-queue
+  namespace: rabbitmq-system
+spec:
+  name: destination-queue
+  vhost: "destination"
+  type: quoum
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: example-rabbit

--- a/docs/examples/shovels/shovel-secret.yaml
+++ b/docs/examples/shovels/shovel-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shovel-secret
+type: Opaque
+data:
+  destUri: # encoded value for shovel destination URI; to learn about how to construct a valid uri, see: https://www.rabbitmq.com/uri-spec.html
+  srcUri: # encoded value shove source URI

--- a/docs/examples/shovels/shovel.yaml
+++ b/docs/examples/shovels/shovel.yaml
@@ -1,0 +1,15 @@
+# for more information, see: https://www.rabbitmq.com/shovel-dynamic.html
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Shovel
+metadata:
+  name: shovel-example
+  namespace: rabbitmq-system
+spec:
+  name: "shovel-example"
+  uriSecret:
+    name: shovel-secret
+  srcQueue: "source-queue"
+  destQueue: "destination-queue"
+  rabbitmqClusterReference:
+    name: example-rabbit

--- a/docs/examples/shovels/vhosts.yaml
+++ b/docs/examples/shovels/vhosts.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: source-vhost
+  namespace: rabbitmq-system
+spec:
+  name: source
+  rabbitmqClusterReference:
+    name: example-rabbit
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: destination-vhost
+  namespace: rabbitmq-system
+spec:
+  name: destination
+  rabbitmqClusterReference:
+    name: example-rabbit


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Adds a Shovel example which can move msg from a classic queue to a quorum queue in different vhosts.

## Additional Context
