### PR TITLE
Docs changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Messaging Topology Operator is covered in several guides:
  - [TLS](https://www.rabbitmq.com/kubernetes/operator/tls-topology-operator.html)
  - [Troubleshooting Messaging Topology Operator](https://www.rabbitmq.com/kubernetes/operator/troubleshooting-topology-operator.html)
 
-In addition, a number of [examples](./docs/examples) can be found in this repository.
+In addition, a number of [examples](./docs/examples) and [Operator API reference](https://github.com/rabbitmq/messaging-topology-operator/blob/main/docs/api/rabbitmq.com.ref.asciidoc) can be found in this repository.
 
 The doc guides are open source. The source can be found in the [RabbitMQ website repository](https://github.com/rabbitmq/rabbitmq-website/)
 under `site/kubernetes`.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,11 @@
+## Messaging Topology Operator examples
+
+This section contains examples on how to create RabbitMQ topology objects using the Messaging Topology Operator.
+
+### Usage
+
+These examples are intended to showcase common use cases for the Messaging Topology Operator. Some examples can be used directly, but
+properties such as resources names and namespaces need to be edited for your own environment. For a more comprehensive guide on how
+to use the Operator, see the [Using Messaging Topology Operator](https://www.rabbitmq.com/kubernetes/operator/using-topology-operator.html)
+guide on `rabbitmq.com` and the Operator [API reference](https://github.com/rabbitmq/messaging-topology-operator/blob/main/docs/api/rabbitmq.com.ref.asciidoc).
+

--- a/docs/examples/bindings/binding.yaml
+++ b/docs/examples/bindings/binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Binding
 metadata:
   name: binding
-  namespace: rabbitmq-system
 spec:
   vhost: "/test-vhost" # default to '/' if not provided
   source: test # an existing exchange

--- a/docs/examples/exchanges/direct-exchange.yaml
+++ b/docs/examples/exchanges/direct-exchange.yaml
@@ -4,7 +4,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Exchange
 metadata:
   name: direct
-  namespace: rabbitmq-system
 spec:
   name: direct-exchange # name of the exchange
   vhost: "/test-vhost" # default to '/' if not provided

--- a/docs/examples/exchanges/fanout-exchange.yaml
+++ b/docs/examples/exchanges/fanout-exchange.yaml
@@ -4,7 +4,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Exchange
 metadata:
   name: fanout
-  namespace: rabbitmq-system
 spec:
   name: fanout-exchange # name of the exchange
   vhost: "/test-vhost" # default to '/' if not provided

--- a/docs/examples/federations/bindings.yaml
+++ b/docs/examples/federations/bindings.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Binding
 metadata:
   name: upstream-binding
-  namespace: rabbitmq-system
 spec:
   vhost: "upstream"
   source: fanout
@@ -16,7 +15,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Binding
 metadata:
   name: downstream-binding
-  namespace: rabbitmq-system
 spec:
   vhost: "downstream"
   source: fanout

--- a/docs/examples/federations/exchanges.yaml
+++ b/docs/examples/federations/exchanges.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Exchange
 metadata:
   name: fanout-upstream
-  namespace: rabbitmq-system
 spec:
   name: fanout
   vhost: "upstream" # default to '/' if not provided
@@ -17,7 +16,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Exchange
 metadata:
   name: fanout-downstream
-  namespace: rabbitmq-system
 spec:
   name: fanout
   vhost: "downstream"

--- a/docs/examples/federations/federation.yaml
+++ b/docs/examples/federations/federation.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Federation
 metadata:
   name: federation-example
-  namespace: rabbitmq-system
 spec:
   name: "origin"
   vhost: "downstream"

--- a/docs/examples/federations/policy.yaml
+++ b/docs/examples/federations/policy.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Policy
 metadata:
   name: federation-policy
-  namespace: rabbitmq-system
 spec:
   name: federation-policy # name of the policy
   vhost: "downstream"

--- a/docs/examples/federations/queues.yaml
+++ b/docs/examples/federations/queues.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
   name: downstream-queue
-  namespace: rabbitmq-system
 spec:
   name: downstream-queue
   vhost: "downstream"
@@ -17,7 +16,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
   name: upstream-queue
-  namespace: rabbitmq-system
 spec:
   name: upstream-queue
   vhost: "upstream"

--- a/docs/examples/federations/vhosts.yaml
+++ b/docs/examples/federations/vhosts.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
   name: upstream-vhost
-  namespace: rabbitmq-system
 spec:
   name: upstream
   rabbitmqClusterReference:
@@ -13,7 +12,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
   name: downstream-vhost
-  namespace: rabbitmq-system
 spec:
   name: downstream
   rabbitmqClusterReference:

--- a/docs/examples/permissions/permission.yaml
+++ b/docs/examples/permissions/permission.yaml
@@ -2,7 +2,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: testuser-permission
-  namespace: rabbitmq-system
 spec:
   vhost: "/" # name of a vhost
   user: "test-user" # name of a RabbitMQ user

--- a/docs/examples/policies/lazy-queue-policy.yaml
+++ b/docs/examples/policies/lazy-queue-policy.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Policy
 metadata:
   name: lazy-queue-policy
-  namespace: rabbitmq-system
 spec:
   name: lazy-queue-policy
   vhost: "test-vhost"

--- a/docs/examples/policies/policy.yaml
+++ b/docs/examples/policies/policy.yaml
@@ -2,7 +2,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Policy
 metadata:
   name: policy-example
-  namespace: rabbitmq-system
 spec:
   name: transient # name of the policy
   vhost: "/a-vhost" # default to '/' if not provided

--- a/docs/examples/queues/lazy-queue.yaml
+++ b/docs/examples/queues/lazy-queue.yaml
@@ -5,7 +5,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Policy
 metadata:
   name: lazy-queue-policy
-  namespace: rabbitmq-system
 spec:
   name: lazy-queue-policy
   vhost: "test-vhost"
@@ -20,7 +19,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
   name: lazy-queue-example
-  namespace: rabbitmq-system
 spec:
   name: lazy-queue-example # matches the pattern "^lazy-queue$" set in lazy-queue-policy
   vhost: "test-vhost"

--- a/docs/examples/queues/quorum-queue.yaml
+++ b/docs/examples/queues/quorum-queue.yaml
@@ -5,7 +5,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
   name: qq-example
-  namespace: rabbitmq-system
 spec:
   name: qq # name of the queue
   vhost: "/test-vhost" # default to '/' if not provided

--- a/docs/examples/shovels/queues.yaml
+++ b/docs/examples/shovels/queues.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
   name: source-queue
-  namespace: rabbitmq-system
 spec:
   name: source-queue
   vhost: "source"
@@ -16,7 +15,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
   name: destination-queue
-  namespace: rabbitmq-system
 spec:
   name: destination-queue
   vhost: "destination"

--- a/docs/examples/shovels/shovel.yaml
+++ b/docs/examples/shovels/shovel.yaml
@@ -4,7 +4,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Shovel
 metadata:
   name: shovel-example
-  namespace: rabbitmq-system
 spec:
   name: "shovel-example"
   uriSecret:

--- a/docs/examples/shovels/vhosts.yaml
+++ b/docs/examples/shovels/vhosts.yaml
@@ -3,7 +3,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
   name: source-vhost
-  namespace: rabbitmq-system
 spec:
   name: source
   rabbitmqClusterReference:
@@ -13,7 +12,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
   name: destination-vhost
-  namespace: rabbitmq-system
 spec:
   name: destination
   rabbitmqClusterReference:

--- a/docs/examples/users/publish-consume-user.yaml
+++ b/docs/examples/users/publish-consume-user.yaml
@@ -22,7 +22,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: testuser-permission
-  namespace: rabbitmq-system
 spec:
   vhost: "test-vhost"
   user: "test-user" # name corresponds to the username we provided in "test-user-credentials" secret

--- a/docs/examples/users/user.yaml
+++ b/docs/examples/users/user.yaml
@@ -2,7 +2,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: User
 metadata:
   name: user-sample
-  namespace: rabbitmq-system
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'

--- a/docs/examples/vhosts/vhost.yaml
+++ b/docs/examples/vhosts/vhost.yaml
@@ -2,7 +2,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
   name: test-vhost
-  namespace: rabbitmq-system
 spec:
   name: test-vhost # vhost name
   rabbitmqClusterReference:


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- We had someone from the community slacks confused about the namespace fields in our examples ([conversation](https://rabbitmq.slack.com/archives/CTMSV81HA/p1623377018039500)). Some of our examples have namespace set to `rabbitmq-system`, some don't. For easier usage, I removed all namespace specification in the examples. This way people can just create objects in the namespace they are targeting with copy-paste. 
- Added a README in docs/examples

## Additional Context
