### PR TITLE
Add warning about queue arguments in crd api description

### DIFF
--- a/api/v1beta1/queue_types.go
+++ b/api/v1beta1/queue_types.go
@@ -21,18 +21,19 @@ import (
 
 // QueueSpec defines the desired state of Queue
 type QueueSpec struct {
-	// Name of the queue; required property
+	// Name of the queue; required property.
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 	// Default to vhost '/'
 	// +kubebuilder:default:=/
 	Vhost string `json:"vhost,omitempty"`
 	Type  string `json:"type,omitempty"`
-	// When set to false queues does not survive server restart
+	// When set to false queues does not survive server restart.
 	Durable bool `json:"durable,omitempty"`
-	// when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes
+	// when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes.
 	AutoDelete bool `json:"autoDelete,omitempty"`
-	// Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000
+	// Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000.
+	// It is not recommended configuring queues through arguments because they cannot be updated once set; we recommend configuring queues through policies instead.
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Arguments *runtime.RawExtension `json:"arguments,omitempty"`

--- a/api/v1beta1/queue_types.go
+++ b/api/v1beta1/queue_types.go
@@ -30,10 +30,10 @@ type QueueSpec struct {
 	Type  string `json:"type,omitempty"`
 	// When set to false queues does not survive server restart.
 	Durable bool `json:"durable,omitempty"`
-	// when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes.
+	// when set to true, queues that have had at least one consumer before are deleted after the last consumer unsubscribes.
 	AutoDelete bool `json:"autoDelete,omitempty"`
 	// Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000.
-	// It is not recommended configuring queues through arguments because they cannot be updated once set; we recommend configuring queues through policies instead.
+	// Configuring queues through arguments is not recommended because they cannot be updated once set; we recommend configuring queues through policies instead.
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Arguments *runtime.RawExtension `json:"arguments,omitempty"`

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: bindings.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: exchanges.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: federations.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: permissions.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: policies.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -40,14 +40,14 @@ spec:
             properties:
               arguments:
                 description: 'Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit:
-                  10000. It is not recommended configuring queues through arguments
-                  because they cannot be updated once set; we recommend configuring
-                  queues through policies instead.'
+                  10000. Configuring queues through arguments is not recommended because
+                  they cannot be updated once set; we recommend configuring queues
+                  through policies instead.'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               autoDelete:
-                description: when set to true, queues that has at least one consumer
-                  before, are deleted after last consumer unsubscribes.
+                description: when set to true, queues that have had at least one consumer
+                  before are deleted after the last consumer unsubscribes.
                 type: boolean
               durable:
                 description: When set to false queues does not survive server restart.

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: queues.rabbitmq.com
 spec:
@@ -40,18 +40,20 @@ spec:
             properties:
               arguments:
                 description: 'Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit:
-                  10000'
+                  10000. It is not recommended configuring queues through arguments
+                  because they cannot be updated once set; we recommend configuring
+                  queues through policies instead.'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               autoDelete:
                 description: when set to true, queues that has at least one consumer
-                  before, are deleted after last consumer unsubscribes
+                  before, are deleted after last consumer unsubscribes.
                 type: boolean
               durable:
-                description: When set to false queues does not survive server restart
+                description: When set to false queues does not survive server restart.
                 type: boolean
               name:
-                description: Name of the queue; required property
+                description: Name of the queue; required property.
                 type: string
               rabbitmqClusterReference:
                 description: Reference to the RabbitmqCluster that the queue will

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: schemareplications.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: shovels.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: users.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: vhosts.rabbitmq.com
 spec:

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -553,12 +553,12 @@ QueueSpec defines the desired state of Queue
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | Name of the queue; required property
+| *`name`* __string__ | Name of the queue; required property.
 | *`vhost`* __string__ | Default to vhost '/'
 | *`type`* __string__ | 
-| *`durable`* __boolean__ | When set to false queues does not survive server restart
-| *`autoDelete`* __boolean__ | when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes
-| *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000
+| *`durable`* __boolean__ | When set to false queues does not survive server restart.
+| *`autoDelete`* __boolean__ | when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes.
+| *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000. It is not recommended configuring queues through arguments because they cannot be updated once set; we recommend configuring queues through policies instead.
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the queue will be created in. Required property.
 |===
 

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -557,8 +557,8 @@ QueueSpec defines the desired state of Queue
 | *`vhost`* __string__ | Default to vhost '/'
 | *`type`* __string__ | 
 | *`durable`* __boolean__ | When set to false queues does not survive server restart.
-| *`autoDelete`* __boolean__ | when set to true, queues that has at least one consumer before, are deleted after last consumer unsubscribes.
-| *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000. It is not recommended configuring queues through arguments because they cannot be updated once set; we recommend configuring queues through policies instead.
+| *`autoDelete`* __boolean__ | when set to true, queues that have had at least one consumer before are deleted after the last consumer unsubscribes.
+| *`arguments`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit: 10000. Configuring queues through arguments is not recommended because they cannot be updated once set; we recommend configuring queues through policies instead.
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the queue will be created in. Required property.
 |===
 


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Add warning about queue arguments in crd api description and recommend people to use policies instead. We already have a comment about this in our queue examples: https://github.com/rabbitmq/messaging-topology-operator/blob/main/docs/examples/queues/lazy-queue.yaml#L2, but let's make the recommendation more obvious.

Suggestions by @MarcialRosales ☺️ 

## Additional Context

Corresponding PR to rabbitmq.com website: https://github.com/rabbitmq/rabbitmq-website/pull/1219
