### PR TITLE
Remove hard-coded `cluster.local` DNS suffix

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -50,5 +50,8 @@ func validateResponseForDeletion(res *http.Response, err error) error {
 // serviceDNSAddress returns the cluster-local DNS entry associated
 // with the provided Service
 func serviceDNSAddress(svc *corev1.Service) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
+	// NOTE: this does not use the `cluster.local` suffix, because that is not
+	// uniform across clusters. See the `clusterDomain` KubeletConfiguration
+	// value for how this can be changed for a cluster.
+	return fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace)
 }

--- a/system_tests/tls_system_test.go
+++ b/system_tests/tls_system_test.go
@@ -31,7 +31,7 @@ var _ = Describe("RabbitmqCluster with TLS", func() {
 		setupTestRabbitmqCluster(k8sClient, targetCluster)
 
 		secretName = fmt.Sprintf("rmq-test-cert-%v", uuid.New())
-		_, _, _ = createTLSSecret(secretName, namespace, "tls-cluster.rabbitmq-system.svc.cluster.local")
+		_, _, _ = createTLSSecret(secretName, namespace, "tls-cluster.rabbitmq-system.svc")
 
 		patchBytes, _ := fixtures.ReadFile("fixtures/patch-test-ca.yaml")
 		_, err := kubectl(


### PR DESCRIPTION
This closes #186

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Remove `cluster.local` suffixes of service names; the cluster suffix is configurable by the cluster administrator.

## Additional Context

I've run the local tests; I found that running `make system-tests` seemed to fail with non-obvious output, but I'm in the process of building the operator and running it in my local cluster.
