### PR TITLE
Remove validation on exchange.spec.type

### DIFF
--- a/api/v1beta1/exchange_types.go
+++ b/api/v1beta1/exchange_types.go
@@ -24,7 +24,6 @@ type ExchangeSpec struct {
 	// +kubebuilder:default:=/
 	Vhost string `json:"vhost,omitempty"`
 	// Cannot be updated
-	// +kubebuilder:validation:Enum=direct;fanout;headers;topic
 	// +kubebuilder:default:=direct
 	Type string `json:"type,omitempty"`
 	// Cannot be updated

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -63,11 +63,6 @@ spec:
               type:
                 default: direct
                 description: Cannot be updated
-                enum:
-                - direct
-                - fanout
-                - headers
-                - topic
                 type: string
               vhost:
                 default: /


### PR DESCRIPTION
This closes #192 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Other types of exchanges could be available in a cluster by enabling plugins like consistent hash or sharding. Removing the type validation on `exchange.spec.type` allows additional exchange types to be used.

## Additional Context
