### PR TITLE
Finalizer refactor

### DIFF
--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: bindings.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: exchanges.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: federations.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: permissions.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: policies.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: queues.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: schemareplications.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: shovels.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: users.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: vhosts.rabbitmq.com
 spec:

--- a/controllers/binding_controller_test.go
+++ b/controllers/binding_controller_test.go
@@ -197,4 +197,19 @@ var _ = Describe("bindingController", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			bindingName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &binding)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Binding
+				Expect(client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.bindings.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/exchange_controller_test.go
+++ b/controllers/exchange_controller_test.go
@@ -197,4 +197,19 @@ var _ = Describe("exchange-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			exchangeName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &exchange)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Exchange
+				Expect(client.Get(ctx, types.NamespacedName{Name: exchange.Name, Namespace: exchange.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.exchanges.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/federation_controller_test.go
+++ b/controllers/federation_controller_test.go
@@ -200,4 +200,19 @@ var _ = Describe("federation-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			name = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &federation)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Federation
+				Expect(client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.federations.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/permission_controller_test.go
+++ b/controllers/permission_controller_test.go
@@ -196,4 +196,19 @@ var _ = Describe("permission-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			permissionName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &permission)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Permission
+				Expect(client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.permissions.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/policy_controller_test.go
+++ b/controllers/policy_controller_test.go
@@ -202,4 +202,19 @@ var _ = Describe("policy-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			policyName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &policy)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Policy
+				Expect(client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.policies.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/queue_controller_test.go
+++ b/controllers/queue_controller_test.go
@@ -197,4 +197,19 @@ var _ = Describe("queue-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			qName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &q)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Queue
+				Expect(client.Get(ctx, types.NamespacedName{Name: q.Name, Namespace: q.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.queues.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/schemareplication_controller_test.go
+++ b/controllers/schemareplication_controller_test.go
@@ -200,4 +200,19 @@ var _ = Describe("schema-replication-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			name = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &replication)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.SchemaReplication
+				Expect(client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.schemareplications.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/shovel_controller_test.go
+++ b/controllers/shovel_controller_test.go
@@ -200,4 +200,19 @@ var _ = Describe("shovel-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			name = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &shovel)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Shovel
+				Expect(client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.shovels.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -231,4 +231,19 @@ var _ = Describe("UserController", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			userName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &user)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.User
+				Expect(client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.users.rabbitmq.com"))
+		})
+	})
 })

--- a/controllers/vhost_controller_test.go
+++ b/controllers/vhost_controller_test.go
@@ -197,4 +197,19 @@ var _ = Describe("vhost-controller", func() {
 			})
 		})
 	})
+
+	Context("finalizer", func() {
+		BeforeEach(func() {
+			vhostName = "finalizer-test"
+		})
+
+		It("sets the correct deletion finalizer to the object", func() {
+			Expect(client.Create(ctx, &vhost)).To(Succeed())
+			Eventually(func() []string {
+				var fetched topology.Vhost
+				Expect(client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &fetched)).To(Succeed())
+				return fetched.ObjectMeta.Finalizers
+			}, 5).Should(ConsistOf("deletion.finalizers.vhosts.rabbitmq.com"))
+		})
+	})
 })

--- a/system_tests/binding_system_test.go
+++ b/system_tests/binding_system_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Binding", func() {
 				},
 			},
 		}
+
 		Expect(k8sClient.Create(ctx, exchange, &client.CreateOptions{})).To(Succeed())
 		queue = &topology.Queue{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- extract universal helpers to remove and add finalizers used for all controllers because: 1) deletion finalizers are all in the same format 2)logic to add and remove finalizers is the same across controllers
- added finalizers tests to make sure added finalizers hasn't changed (has to stay the same for compatibility)
- updated controller-gen annotations in all CRD

## Additional Context
