### PR TITLE
Fix flaky finalizer test

### DIFF
--- a/controllers/binding_controller_test.go
+++ b/controllers/binding_controller_test.go
@@ -208,7 +208,10 @@ var _ = Describe("bindingController", func() {
 				Expect(client.Create(ctx, &binding)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Binding
-					Expect(client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.bindings.rabbitmq.com"))
 			})

--- a/controllers/exchange_controller_test.go
+++ b/controllers/exchange_controller_test.go
@@ -208,7 +208,10 @@ var _ = Describe("exchange-controller", func() {
 				Expect(client.Create(ctx, &exchange)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Exchange
-					Expect(client.Get(ctx, types.NamespacedName{Name: exchange.Name, Namespace: exchange.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: exchange.Name, Namespace: exchange.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.exchanges.rabbitmq.com"))
 			})

--- a/controllers/federation_controller_test.go
+++ b/controllers/federation_controller_test.go
@@ -211,7 +211,10 @@ var _ = Describe("federation-controller", func() {
 				Expect(client.Create(ctx, &federation)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Federation
-					Expect(client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.federations.rabbitmq.com"))
 			})

--- a/controllers/permission_controller_test.go
+++ b/controllers/permission_controller_test.go
@@ -207,7 +207,10 @@ var _ = Describe("permission-controller", func() {
 				Expect(client.Create(ctx, &permission)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Permission
-					Expect(client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.permissions.rabbitmq.com"))
 			})

--- a/controllers/policy_controller_test.go
+++ b/controllers/policy_controller_test.go
@@ -213,7 +213,10 @@ var _ = Describe("policy-controller", func() {
 				Expect(client.Create(ctx, &policy)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Policy
-					Expect(client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.policies.rabbitmq.com"))
 			})

--- a/controllers/queue_controller_test.go
+++ b/controllers/queue_controller_test.go
@@ -208,7 +208,10 @@ var _ = Describe("queue-controller", func() {
 				Expect(client.Create(ctx, &queue)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Queue
-					Expect(client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.queues.rabbitmq.com"))
 			})

--- a/controllers/schemareplication_controller_test.go
+++ b/controllers/schemareplication_controller_test.go
@@ -211,7 +211,10 @@ var _ = Describe("schema-replication-controller", func() {
 				Expect(client.Create(ctx, &replication)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.SchemaReplication
-					Expect(client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.schemareplications.rabbitmq.com"))
 			})

--- a/controllers/shovel_controller_test.go
+++ b/controllers/shovel_controller_test.go
@@ -211,7 +211,10 @@ var _ = Describe("shovel-controller", func() {
 				Expect(client.Create(ctx, &shovel)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Shovel
-					Expect(client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.shovels.rabbitmq.com"))
 			})

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -240,7 +240,10 @@ var _ = Describe("UserController", func() {
 				Expect(client.Create(ctx, &user)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.User
-					Expect(client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.users.rabbitmq.com"))
 			})

--- a/controllers/vhost_controller_test.go
+++ b/controllers/vhost_controller_test.go
@@ -208,7 +208,10 @@ var _ = Describe("vhost-controller", func() {
 				Expect(client.Create(ctx, &vhost)).To(Succeed())
 				Eventually(func() []string {
 					var fetched topology.Vhost
-					Expect(client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &fetched)).To(Succeed())
+					err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.vhosts.rabbitmq.com"))
 			})


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
Flakes are great in corn 🌽 but not in your tests.

## Additional Context
Chose to declare the error in a var and then check if it's nil, rather than declaring everying inside the `if` condition, for better readability.