### PR TITLE
Make logger configurable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.18.19, v1.19.11, v1.20.7]
+        k8s: [v1.18.19, v1.21.1]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 check-env-docker-repo: check-env-registry-server set-operator-image-repo
 
 set-operator-image-repo:
-OPERATOR_IMAGE=p-rabbitmq-for-kubernetes/messaging-topology-operator
+OPERATOR_IMAGE?=p-rabbitmq-for-kubernetes/messaging-topology-operator
 
 operator-namespace:
 ifeq (, $(K8S_OPERATOR_NAMESPACE))

--- a/config/default/overlays/dev/manager_image_patch.yaml
+++ b/config/default/overlays/dev/manager_image_patch.yaml
@@ -17,3 +17,4 @@ spec:
       - image: ((operator_docker_image))
         name: manager
         imagePullPolicy: Always
+        args: ["--zap-devel"]

--- a/config/default/overlays/kind/manager_image_patch.yaml
+++ b/config/default/overlays/kind/manager_image_patch.yaml
@@ -17,3 +17,4 @@ spec:
       - image: ((operator_docker_image))
         name: manager
         imagePullPolicy: IfNotPresent
+        args: ["--zap-devel"]

--- a/internal/cluster_reference.go
+++ b/internal/cluster_reference.go
@@ -40,7 +40,7 @@ func ParseRabbitmqClusterReference(ctx context.Context, c client.Client, rmq top
 				}
 			}
 		}
-		if isAllowed == false {
+		if !isAllowed {
 			return nil, nil, nil, ResourceNotAllowedError
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -43,9 +43,13 @@ func init() {
 func main() {
 	var metricsAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
+
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
 	if operatorNamespace == "" {

--- a/system_tests/permissions_system_test.go
+++ b/system_tests/permissions_system_test.go
@@ -2,6 +2,7 @@ package system_tests
 
 import (
 	"context"
+
 	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,10 +46,8 @@ var _ = Describe("Permission", func() {
 		}
 		var generatedSecret = &corev1.Secret{}
 		Eventually(func() error {
-			var err error
-			err = k8sClient.Get(ctx, generatedSecretKey, generatedSecret)
-			return err
-		}, 30, 2).Should(BeNil())
+			return k8sClient.Get(ctx, generatedSecretKey, generatedSecret)
+		}, 30, 2).Should(Succeed())
 		username = string(generatedSecret.Data["username"])
 
 		permission = &topology.Permission{

--- a/system_tests/user_system_test.go
+++ b/system_tests/user_system_test.go
@@ -50,10 +50,8 @@ var _ = Describe("Users", func() {
 			}
 			var generatedSecret = &corev1.Secret{}
 			Eventually(func() error {
-				var err error
-				err = k8sClient.Get(ctx, generatedSecretKey, generatedSecret)
-				return err
-			}, 30, 2).Should(BeNil())
+				return k8sClient.Get(ctx, generatedSecretKey, generatedSecret)
+			}, 30, 2).Should(Succeed())
 			Expect(generatedSecret.Data).To(HaveKey("username"))
 			Expect(generatedSecret.Data).To(HaveKey("password"))
 
@@ -184,10 +182,8 @@ var _ = Describe("Users", func() {
 			}
 			var generatedSecret = &corev1.Secret{}
 			Eventually(func() error {
-				var err error
-				err = k8sClient.Get(ctx, generatedSecretKey, generatedSecret)
-				return err
-			}, 30, 2).Should(BeNil())
+				return k8sClient.Get(ctx, generatedSecretKey, generatedSecret)
+			}, 30, 2).Should(Succeed())
 			Expect(generatedSecret.Data).To(HaveKeyWithValue("username", []uint8("`got*special_ch$racter5")))
 			Expect(generatedSecret.Data).To(HaveKeyWithValue("password", []uint8("-grace.hopper_9453$")))
 		})


### PR DESCRIPTION
Before this commit, `devMode` was hard-coded.

Resolves #222

Same as done in https://github.com/rabbitmq/cluster-operator/pull/554