### PR TITLE
Add spec.endpoints for schemareplication.rabbitmq.com

### DIFF
--- a/api/v1beta1/schemareplication_types.go
+++ b/api/v1beta1/schemareplication_types.go
@@ -21,10 +21,14 @@ type SchemaReplicationSpec struct {
 	// +kubebuilder:validation:Required
 	RabbitmqClusterReference RabbitmqClusterReference `json:"rabbitmqClusterReference"`
 	// Defines a Secret which contains credentials to be used for schema replication.
-	// The Secret must contain the keys `endpoints`, `username` and `password` in its Data field, or operator will error.
-	// `endpoints` should be one or multiple endpoints separated by ','.
+	// The Secret must contain the keys `username` and `password` in its Data field, or operator will error.
 	// +kubebuilder:validation:Required
 	UpstreamSecret *corev1.LocalObjectReference `json:"upstreamSecret,omitempty"`
+	// endpoints should be one or multiple endpoints separated by ','.
+	// Must provide either spec.endpoints or endpoints in spec.upstreamSecret.
+	// When endpoints are provided in both spec.endpoints and spec.upstreamSecret, spec.endpoints takes
+	// precedence.
+	Endpoints string `json:"endpoints,omitempty"`
 }
 
 // SchemaReplicationStatus defines the observed state of SchemaReplication

--- a/api/v1beta1/schemareplication_types_test.go
+++ b/api/v1beta1/schemareplication_types_test.go
@@ -23,6 +23,7 @@ var _ = Describe("schemaReplication spec", func() {
 				UpstreamSecret: &corev1.LocalObjectReference{
 					Name: "a-secret",
 				},
+				Endpoints: "abc.rmq.com:1234",
 			}}
 		Expect(k8sClient.Create(context.Background(), &replication)).To(Succeed())
 
@@ -35,5 +36,6 @@ var _ = Describe("schemaReplication spec", func() {
 			Name: "some-cluster",
 		}))
 		Expect(fetched.Spec.UpstreamSecret.Name).To(Equal("a-secret"))
+		Expect(fetched.Spec.Endpoints).To(Equal("abc.rmq.com:1234"))
 	})
 })

--- a/api/v1beta1/schemareplication_webhook_test.go
+++ b/api/v1beta1/schemareplication_webhook_test.go
@@ -17,6 +17,7 @@ var _ = Describe("schema-replication webhook", func() {
 			UpstreamSecret: &corev1.LocalObjectReference{
 				Name: "a-secret",
 			},
+			Endpoints: "abc.rmq.com:1234",
 			RabbitmqClusterReference: RabbitmqClusterReference{
 				Name: "a-cluster",
 			},
@@ -36,6 +37,12 @@ var _ = Describe("schema-replication webhook", func() {
 		updated.Spec.UpstreamSecret = &corev1.LocalObjectReference{
 			Name: "a-different-secret",
 		}
+		Expect(updated.ValidateUpdate(&replication)).To(Succeed())
+	})
+
+	It("allows updates on spec.endpoints", func() {
+		updated := replication.DeepCopy()
+		updated.Spec.Endpoints = "abc.new-rmq:1111"
 		Expect(updated.ValidateUpdate(&replication)).To(Succeed())
 	})
 })

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -38,6 +38,12 @@ spec:
           spec:
             description: SchemaReplicationSpec defines the desired state of SchemaReplication
             properties:
+              endpoints:
+                description: endpoints should be one or multiple endpoints separated
+                  by ','. Must provide either spec.endpoints or endpoints in spec.upstreamSecret.
+                  When endpoints are provided in both spec.endpoints and spec.upstreamSecret,
+                  spec.endpoints takes precedence.
+                type: string
               rabbitmqClusterReference:
                 description: Reference to the RabbitmqCluster that schema replication
                   would be set for. Must be an existing cluster.
@@ -54,9 +60,8 @@ spec:
                 type: object
               upstreamSecret:
                 description: Defines a Secret which contains credentials to be used
-                  for schema replication. The Secret must contain the keys `endpoints`,
-                  `username` and `password` in its Data field, or operator will error.
-                  `endpoints` should be one or multiple endpoints separated by ','.
+                  for schema replication. The Secret must contain the keys `username`
+                  and `password` in its Data field, or operator will error.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/controllers/schemareplication_controller.go
+++ b/controllers/schemareplication_controller.go
@@ -174,7 +174,7 @@ func (r *SchemaReplicationReconciler) getUpstreamEndpoints(ctx context.Context, 
 		return internal.UpstreamEndpoints{}, err
 	}
 
-	endpoints, err := internal.GenerateSchemaReplicationParameters(secret)
+	endpoints, err := internal.GenerateSchemaReplicationParameters(secret, replication.Spec.Endpoints)
 	if err != nil {
 		return internal.UpstreamEndpoints{}, err
 	}

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -665,7 +665,8 @@ SchemaReplicationSpec defines the desired state of SchemaReplication
 |===
 | Field | Description
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that schema replication would be set for. Must be an existing cluster.
-| *`upstreamSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Defines a Secret which contains credentials to be used for schema replication. The Secret must contain the keys `endpoints`, `username` and `password` in its Data field, or operator will error. `endpoints` should be one or multiple endpoints separated by ','.
+| *`upstreamSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Defines a Secret which contains credentials to be used for schema replication. The Secret must contain the keys `username` and `password` in its Data field, or operator will error.
+| *`endpoints`* __string__ | endpoints should be one or multiple endpoints separated by ','. Must provide either spec.endpoints or endpoints in spec.upstreamSecret. When endpoints are provided in both spec.endpoints and spec.upstreamSecret, spec.endpoints takes precedence.
 |===
 
 

--- a/internal/schema_replication.go
+++ b/internal/schema_replication.go
@@ -21,7 +21,7 @@ type UpstreamEndpoints struct {
 	Endpoints []string `json:"endpoints"`
 }
 
-func GenerateSchemaReplicationParameters(secret *corev1.Secret) (UpstreamEndpoints, error) {
+func GenerateSchemaReplicationParameters(secret *corev1.Secret, endpoints string) (UpstreamEndpoints, error) {
 	username, ok := secret.Data["username"]
 	if !ok {
 		return UpstreamEndpoints{}, fmt.Errorf("could not find username in secret %s", secret.Name)
@@ -31,12 +31,15 @@ func GenerateSchemaReplicationParameters(secret *corev1.Secret) (UpstreamEndpoin
 		return UpstreamEndpoints{}, fmt.Errorf("could not find password in secret %s", secret.Name)
 	}
 
-	endpoints, ok := secret.Data["endpoints"]
-	if !ok {
-		return UpstreamEndpoints{}, fmt.Errorf("could not find endpoints in secret %s", secret.Name)
+	if endpoints == "" {
+		endpointsFromSecret, ok := secret.Data["endpoints"]
+		if !ok {
+			return UpstreamEndpoints{}, fmt.Errorf("could not find endpoints in secret %s or from spec.endpoints", secret.Name)
+		}
+		endpoints = string(endpointsFromSecret)
 	}
 
-	endpointsList := strings.Split(string(endpoints), ",")
+	endpointsList := strings.Split(endpoints, ",")
 
 	return UpstreamEndpoints{
 		Username:  string(username),

--- a/internal/schema_replication_test.go
+++ b/internal/schema_replication_test.go
@@ -14,22 +14,52 @@ var _ = Describe("GenerateSchemaReplicationParameters", func() {
 		secret = corev1.Secret{
 			Type: corev1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				"username":  []byte("a-random-user"),
-				"password":  []byte("a-random-password"),
-				"endpoints": []byte("a.endpoints.local:5672,b.endpoints.local:5672,c.endpoints.local:5672"),
+				"username": []byte("a-random-user"),
+				"password": []byte("a-random-password"),
 			},
 		}
 	})
+	When("endpoints are provided as function parameter", func() {
+		It("generates expected replication parameters", func() {
+			parameters, err := internal.GenerateSchemaReplicationParameters(&secret, "a.endpoints.local:5672,b.endpoints.local:5672,c.endpoints.local:5672")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parameters.Username).To(Equal("a-random-user"))
+			Expect(parameters.Password).To(Equal("a-random-password"))
+			Expect(parameters.Endpoints).To(Equal([]string{
+				"a.endpoints.local:5672",
+				"b.endpoints.local:5672",
+				"c.endpoints.local:5672",
+			}))
+		})
+	})
 
-	It("generates expected replication parameters", func() {
-		parameters, err := internal.GenerateSchemaReplicationParameters(&secret)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(parameters.Username).To(Equal("a-random-user"))
-		Expect(parameters.Password).To(Equal("a-random-password"))
-		Expect(parameters.Endpoints).To(Equal([]string{
-			"a.endpoints.local:5672",
-			"b.endpoints.local:5672",
-			"c.endpoints.local:5672",
-		}))
+	When("endpoints are provided in the secret object and as function parameter", func() {
+		It("endpoints parameter takes precedence over endpoints from secret object", func() {
+			secret.Data["endpoints"] = []byte("some-url-value:1234")
+			parameters, err := internal.GenerateSchemaReplicationParameters(&secret, "a.endpoints.local:5672,b.endpoints.local:5672,c.endpoints.local:5672")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parameters.Username).To(Equal("a-random-user"))
+			Expect(parameters.Password).To(Equal("a-random-password"))
+			Expect(parameters.Endpoints).To(Equal([]string{
+				"a.endpoints.local:5672",
+				"b.endpoints.local:5672",
+				"c.endpoints.local:5672",
+			}))
+		})
+	})
+
+	When("endpoints are provided only in the secret object", func() {
+		It("generates expected replication parameters", func() {
+			secret.Data["endpoints"] = []byte("a.endpoints.local:5672,b.endpoints.local:5672,c.endpoints.local:5672")
+			parameters, err := internal.GenerateSchemaReplicationParameters(&secret, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parameters.Username).To(Equal("a-random-user"))
+			Expect(parameters.Password).To(Equal("a-random-password"))
+			Expect(parameters.Endpoints).To(Equal([]string{
+				"a.endpoints.local:5672",
+				"b.endpoints.local:5672",
+				"c.endpoints.local:5672",
+			}))
+		})
 	})
 })

--- a/system_tests/schema_replication_system_test.go
+++ b/system_tests/schema_replication_system_test.go
@@ -35,7 +35,6 @@ var _ = Describe("schema replication", func() {
 			},
 			Type: corev1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				"endpoints": []byte("abc.endpoints.local:5672,efg.endpoints.local:1234"),
 				"username":  []byte("some-username"),
 				"password":  []byte("some-password"),
 			},
@@ -47,6 +46,7 @@ var _ = Describe("schema replication", func() {
 				Namespace: namespace,
 			},
 			Spec: topology.SchemaReplicationSpec{
+				Endpoints: "abc.endpoints.local:5672,efg.endpoints.local:1234",
 				UpstreamSecret: &corev1.LocalObjectReference{
 					Name: "endpoints-secret",
 				},


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Feedback and suggestion from @pjk25 🥳 

Add spec.endpoints for schemareplication.rabbitmq.com, so that: 
 - users can then reference the default user secret
 - it might be better for vault integration in the future because username and password are fetched from vault, but not the list of endpoints. So this creates better separation
 - this change is not a breaking change, because we can still let people specify list of endpoints in the secret, but the top level endpoints property takes precedence

## Additional Context

Tested in unit and system tests.