### PR TITLE
Remove update/create permissions for rmq, secrets, and services

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,20 +19,16 @@ rules:
   resources:
   - secrets
   verbs:
-  - create
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
-  - create
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - rabbitmq.com
@@ -159,10 +155,8 @@ rules:
   resources:
   - rabbitmqclusters
   verbs:
-  - create
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - rabbitmq.com
@@ -170,7 +164,6 @@ rules:
   - rabbitmqclusters/status
   verbs:
   - get
-  - update
 - apiGroups:
   - rabbitmq.com
   resources:

--- a/controllers/permission_controller.go
+++ b/controllers/permission_controller.go
@@ -34,7 +34,6 @@ type PermissionReconciler struct {
 
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=permissions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=permissions/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
 
 func (r *PermissionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)

--- a/controllers/queue_controller.go
+++ b/controllers/queue_controller.go
@@ -40,7 +40,6 @@ type QueueReconciler struct {
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=queues/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/status,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;create;patch
 

--- a/controllers/queue_controller.go
+++ b/controllers/queue_controller.go
@@ -38,10 +38,10 @@ type QueueReconciler struct {
 
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=queues,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=queues/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/status,verbs=get;update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;create;patch
 
 func (r *QueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -50,7 +50,6 @@ type UserReconciler struct {
 
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=users,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=users/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
 
 func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -50,6 +50,7 @@ type UserReconciler struct {
 
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=users,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=users/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create
 
 func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)

--- a/system_tests/schema_replication_system_test.go
+++ b/system_tests/schema_replication_system_test.go
@@ -35,8 +35,8 @@ var _ = Describe("schema replication", func() {
 			},
 			Type: corev1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				"username":  []byte("some-username"),
-				"password":  []byte("some-password"),
+				"username": []byte("some-username"),
+				"password": []byte("some-password"),
 			},
 		}
 		Expect(k8sClient.Create(ctx, &endpointsSecret, &client.CreateOptions{})).To(Succeed())


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- Remove update/create permissions for rmq, secrets, and services, and update permission for rabbitmqclusters/status
- There were also multiple kubebuilder annotation to configure permissions for secret object, I removed them as part of the same commit

**Edit** permission to create secrets is necessary for `users.rabbitmq.com`. The operator supports creating generated credentials for users and therefore needs to be able to create k8s secret.


## Additional Context
