### PR TITLE
Fix endless reconcile issue

### DIFF
--- a/api/v1beta1/conditions_test.go
+++ b/api/v1beta1/conditions_test.go
@@ -4,29 +4,39 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Conditions", func() {
-	Context("Ready", func() {
+	Describe("Ready", func() {
 		It("returns 'Ready' condition set to true", func() {
-			c := Ready()
+			c := Ready(nil)
 			Expect(string(c.Type)).To(Equal("Ready"))
 			Expect(c.Status).To(Equal(corev1.ConditionTrue))
 			Expect(c.Reason).To(Equal("SuccessfulCreateOrUpdate"))
-			Expect(c.LastTransitionTime).NotTo(Equal(metav1.Time{})) // has been set; not empty
+			Expect(c.LastTransitionTime.IsZero()).To(BeFalse())
 		})
-
 	})
-
-	Context("NotReady", func() {
+	Describe("NotReady", func() {
 		It("returns 'Ready' condition set to false", func() {
-			c := NotReady("fail to declare queue")
+			c := NotReady("fail to declare queue", nil)
 			Expect(string(c.Type)).To(Equal("Ready"))
 			Expect(c.Status).To(Equal(corev1.ConditionFalse))
 			Expect(c.Reason).To(Equal("FailedCreateOrUpdate"))
 			Expect(c.Message).To(Equal("fail to declare queue"))
-			Expect(c.LastTransitionTime).NotTo(Equal(metav1.Time{})) // has been set; not empty
+			Expect(c.LastTransitionTime.IsZero()).To(BeFalse())
+		})
+	})
+	Context("LastTransitionTime", func() {
+		It("changes only if status changes", func() {
+			c1 := Ready(nil)
+			Expect(c1.LastTransitionTime.IsZero()).To(BeFalse())
+			c2 := Ready([]Condition{
+				Condition{Type: "I'm some other type"},
+				c1,
+			})
+			Expect(c2.LastTransitionTime.Time).To(BeTemporally("==", c1.LastTransitionTime.Time))
+			c3 := NotReady("some message", []Condition{c2})
+			Expect(c3.LastTransitionTime.Time).To(BeTemporally(">", c2.LastTransitionTime.Time))
 		})
 	})
 })

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -85,7 +85,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -83,7 +83,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -104,7 +104,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -93,7 +93,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -95,7 +95,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -86,7 +86,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -78,7 +78,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -131,7 +131,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -93,7 +93,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -72,7 +72,7 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: The last time this Condition type changed.
+                      description: The last time this Condition status changed.
                       format: date-time
                       type: string
                     message:

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -145,7 +145,7 @@ BindingStatus defines the observed state of Binding
 | Field | Description
 | *`type`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-conditiontype[$$ConditionType$$]__ | Type indicates the scope of the custom resource status addressed by the condition.
 | *`status`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core[$$ConditionStatus$$]__ | True, False, or Unknown
-| *`lastTransitionTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta[$$Time$$]__ | The last time this Condition type changed.
+| *`lastTransitionTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta[$$Time$$]__ | The last time this Condition status changed.
 | *`reason`* __string__ | One word, camel-case reason for current status of the condition.
 | *`message`* __string__ | Full text reason for current status of the condition.
 |===


### PR DESCRIPTION
Fixes #250

Before this commit, the LastTransitionTime was updated in every
reconcile. This is wrong because LastTransitionTime should only be
updated if the status transitions from one to the other.

This led to endless reconciliations because updating the status leads to
a new resourceVersion resulting in a new reoncile.

With sufficient objects (>100), it takes more than one second between
reconciling the same object. Since the granularity of lastTransitionTime
is 1 second, this ended up in endless updates of lastTranistionTime and
therefore resourceVersion.