### PR TITLE
Add routingKey to the binding example

### DIFF
--- a/docs/examples/bindings/binding.yaml
+++ b/docs/examples/bindings/binding.yaml
@@ -7,6 +7,7 @@ spec:
   source: test # an existing exchange
   destination: test # an existing queue or exchange
   destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "a-routing-key"
   rabbitmqClusterReference:
     name: test # rabbitmqCluster must exist in the same namespace as this resource
 # status:


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

There were two people asking for whether it's possible to set routing key or not, so adding it to the example:
- https://github.com/rabbitmq/messaging-topology-operator/discussions/322
- https://github.com/rabbitmq/messaging-topology-operator/discussions/318

## Additional Context
