### PR TITLE
Update logic deletion on user and permission controller

### DIFF
--- a/api/v1beta1/user_types.go
+++ b/api/v1beta1/user_types.go
@@ -44,6 +44,8 @@ type UserStatus struct {
 	Conditions         []Condition `json:"conditions,omitempty"`
 	// Provides a reference to a Secret object containing the user credentials.
 	Credentials *corev1.LocalObjectReference `json:"credentials,omitempty"`
+	// Provide rabbitmq Username
+	Username string `json:"username"`
 }
 
 // UserTag defines the level of access to the management UI allocated to the user.

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -140,6 +140,11 @@ spec:
                   which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              username:
+                description: Provide rabbitmq Username
+                type: string
+            required:
+            - username
             type: object
         type: object
     served: true

--- a/controllers/permission_controller_test.go
+++ b/controllers/permission_controller_test.go
@@ -32,6 +32,8 @@ var _ = Describe("permission-controller", func() {
 					RabbitmqClusterReference: topology.RabbitmqClusterReference{
 						Name: "example-rabbit",
 					},
+					User:  "example",
+					Vhost: "example",
 				},
 			}
 		})

--- a/controllers/permission_controller_test.go
+++ b/controllers/permission_controller_test.go
@@ -19,9 +19,11 @@ import (
 
 var _ = Describe("permission-controller", func() {
 	var permission topology.Permission
+	var user topology.User
 	var permissionName string
+	var userName string
 
-	When("validating RabbitMQ Client failures", func() {
+	When("validating RabbitMQ Client failures with username", func() {
 		JustBeforeEach(func() {
 			permission = topology.Permission{
 				ObjectMeta: metav1.ObjectMeta{
@@ -41,7 +43,7 @@ var _ = Describe("permission-controller", func() {
 		Context("creation", func() {
 			When("the RabbitMQ Client returns a HTTP error response", func() {
 				BeforeEach(func() {
-					permissionName = "test-http-error"
+					permissionName = "test-with-username-http-error"
 					fakeRabbitMQClient.UpdatePermissionsInReturns(&http.Response{
 						Status:     "418 I'm a teapot",
 						StatusCode: 418,
@@ -69,7 +71,7 @@ var _ = Describe("permission-controller", func() {
 
 			When("the RabbitMQ Client returns a Go error response", func() {
 				BeforeEach(func() {
-					permissionName = "test-go-error"
+					permissionName = "test-with-username-go-error"
 					fakeRabbitMQClient.UpdatePermissionsInReturns(nil, errors.New("a go failure"))
 				})
 
@@ -94,7 +96,7 @@ var _ = Describe("permission-controller", func() {
 
 			When("success", func() {
 				BeforeEach(func() {
-					permissionName = "test-create-success"
+					permissionName = "test-with-username-create-success"
 					fakeRabbitMQClient.UpdatePermissionsInReturns(&http.Response{
 						Status:     "201 Created",
 						StatusCode: http.StatusCreated,
@@ -144,7 +146,7 @@ var _ = Describe("permission-controller", func() {
 
 			When("the RabbitMQ Client returns a HTTP error response", func() {
 				BeforeEach(func() {
-					permissionName = "delete-permission-http-error"
+					permissionName = "delete-with-username-permission-http-error"
 					fakeRabbitMQClient.ClearPermissionsInReturns(&http.Response{
 						Status:     "502 Bad Gateway",
 						StatusCode: http.StatusBadGateway,
@@ -164,7 +166,7 @@ var _ = Describe("permission-controller", func() {
 
 			When("the RabbitMQ Client returns a Go error response", func() {
 				BeforeEach(func() {
-					permissionName = "delete-go-error"
+					permissionName = "delete-with-username-go-error"
 					fakeRabbitMQClient.ClearPermissionsInReturns(nil, errors.New("some error"))
 				})
 
@@ -180,7 +182,7 @@ var _ = Describe("permission-controller", func() {
 
 			When("the RabbitMQ Client successfully deletes a permission", func() {
 				BeforeEach(func() {
-					permissionName = "delete-permission-success"
+					permissionName = "delete-with-username-permission-success"
 					fakeRabbitMQClient.ClearPermissionsInReturns(&http.Response{
 						Status:     "204 No Content",
 						StatusCode: http.StatusNoContent,
@@ -202,7 +204,7 @@ var _ = Describe("permission-controller", func() {
 
 		Context("finalizer", func() {
 			BeforeEach(func() {
-				permissionName = "finalizer-test"
+				permissionName = "finalizer-with-username-test"
 			})
 
 			It("sets the correct deletion finalizer to the object", func() {
@@ -215,6 +217,213 @@ var _ = Describe("permission-controller", func() {
 					}
 					return fetched.ObjectMeta.Finalizers
 				}, 5).Should(ConsistOf("deletion.finalizers.permissions.rabbitmq.com"))
+			})
+		})
+	})
+
+	When("validating RabbitMQ Client failures with userRef", func() {
+		JustBeforeEach(func() {
+			user = topology.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      userName,
+					Namespace: "default",
+				},
+				Spec: topology.UserSpec{
+					RabbitmqClusterReference: topology.RabbitmqClusterReference{
+						Name:      "example-rabbit",
+						Namespace: "default",
+					},
+				},
+			}
+			permission = topology.Permission{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      permissionName,
+					Namespace: "default",
+				},
+				Spec: topology.PermissionSpec{
+					RabbitmqClusterReference: topology.RabbitmqClusterReference{
+						Name:      "example-rabbit",
+						Namespace: "default",
+					},
+					UserReference: &corev1.LocalObjectReference{
+						Name: userName,
+					},
+					Vhost: "example",
+				},
+			}
+			fakeRabbitMQClient.UpdatePermissionsInReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			fakeRabbitMQClient.ClearPermissionsInReturns(&http.Response{
+				Status:     "204 No Content",
+				StatusCode: http.StatusNoContent,
+			}, nil)
+			fakeRabbitMQClient.PutUserReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			fakeRabbitMQClient.DeleteUserReturns(&http.Response{
+				Status:     "204 No Content",
+				StatusCode: http.StatusNoContent,
+			}, nil)
+		})
+
+		Context("creation", func() {
+			When("user not exist", func() {
+				BeforeEach(func() {
+					permissionName = "test-with-userref-create-not-exist"
+					userName = "example-create-not-exist"
+				})
+
+				It("sets the status condition 'Ready' to 'true' ", func() {
+					Expect(client.Create(ctx, &permission)).To(Succeed())
+					EventuallyWithOffset(1, func() []topology.Condition {
+						_ = client.Get(
+							ctx,
+							types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace},
+							&permission,
+						)
+
+						return permission.Status.Conditions
+					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(topology.ConditionType("Ready")),
+						"Reason":  Equal("FailedCreateOrUpdate"),
+						"Message": Equal("failed create Permission, missing User"),
+						"Status":  Equal(corev1.ConditionFalse),
+					})))
+				})
+			})
+
+			When("success", func() {
+				BeforeEach(func() {
+					permissionName = "test-with-userref-create-success"
+					userName = "example-create-success"
+				})
+
+				It("sets the status condition 'Ready' to 'true' ", func() {
+					Expect(client.Create(ctx, &user)).To(Succeed())
+					Expect(client.Create(ctx, &permission)).To(Succeed())
+					EventuallyWithOffset(1, func() []topology.Condition {
+						_ = client.Get(
+							ctx,
+							types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace},
+							&permission,
+						)
+
+						return permission.Status.Conditions
+					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(topology.ConditionType("Ready")),
+						"Reason": Equal("SuccessfulCreateOrUpdate"),
+						"Status": Equal(corev1.ConditionTrue),
+					})))
+				})
+			})
+		})
+
+		Context("deletion", func() {
+			JustBeforeEach(func() {
+				Expect(client.Create(ctx, &user)).To(Succeed())
+				Expect(client.Create(ctx, &permission)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace},
+						&permission,
+					)
+
+					return permission.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(topology.ConditionType("Ready")),
+					"Reason": Equal("SuccessfulCreateOrUpdate"),
+					"Status": Equal(corev1.ConditionTrue),
+				})))
+			})
+
+			When("Secret User is removed first", func() {
+				BeforeEach(func() {
+					permissionName = "test-with-userref-delete-secret"
+					userName = "example-delete-secret-first"
+				})
+
+				It("publishes a 'warning' event", func() {
+					Expect(client.Delete(ctx, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      user.Name + "-user-credentials",
+							Namespace: user.Namespace,
+						},
+					})).To(Succeed())
+					Expect(client.Delete(ctx, &permission)).To(Succeed())
+					Eventually(func() bool {
+						err := client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &topology.Permission{})
+						return apierrors.IsNotFound(err)
+					}, 5).Should(BeTrue())
+					observedEvents := observedEvents()
+					Expect(observedEvents).NotTo(ContainElement("Warning FailedDelete failed to delete permission"))
+					Expect(observedEvents).To(ContainElement("Normal SuccessfulDelete successfully deleted permission"))
+				})
+			})
+
+			When("User is removed first", func() {
+				BeforeEach(func() {
+					permissionName = "test-with-userref-delete-user"
+					userName = "example-delete-user-first"
+				})
+
+				It("publishes a 'warning' event", func() {
+					Expect(client.Delete(ctx, &user)).To(Succeed())
+					Eventually(func() bool {
+						err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
+						return apierrors.IsNotFound(err)
+					}, 5).Should(BeTrue())
+					Expect(client.Delete(ctx, &permission)).To(Succeed())
+					Eventually(func() bool {
+						err := client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &topology.Permission{})
+						return apierrors.IsNotFound(err)
+					}, 5).Should(BeTrue())
+					observedEvents := observedEvents()
+					Expect(observedEvents).NotTo(ContainElement("Warning FailedDelete failed to delete permission"))
+					Expect(observedEvents).To(ContainElement("Warning UserNotExist user already removed; no need to delete permission"))
+					Expect(observedEvents).To(ContainElement("Normal SuccessfulDelete successfully deleted permission"))
+				})
+			})
+
+			When("success", func() {
+				BeforeEach(func() {
+					permissionName = "test-with-userref-delete-success"
+					userName = "example-delete-success"
+				})
+
+				It("publishes a 'warning' event", func() {
+					Expect(client.Delete(ctx, &permission)).To(Succeed())
+					Eventually(func() bool {
+						err := client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &topology.Permission{})
+						return apierrors.IsNotFound(err)
+					}, 5).Should(BeTrue())
+					observedEvents := observedEvents()
+					Expect(observedEvents).NotTo(ContainElement("Warning FailedDelete failed to delete permission"))
+					Expect(observedEvents).To(ContainElement("Normal SuccessfulDelete successfully deleted permission"))
+				})
+			})
+		})
+
+		Context("ownerref", func() {
+			BeforeEach(func() {
+				permissionName = "ownerref-with-userref-test"
+				userName = "example-ownerref"
+			})
+
+			It("sets the correct deletion ownerref to the object", func() {
+				Expect(client.Create(ctx, &user)).To(Succeed())
+				Expect(client.Create(ctx, &permission)).To(Succeed())
+				Eventually(func() []metav1.OwnerReference {
+					var fetched topology.Permission
+					err := client.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &fetched)
+					if err != nil {
+						return []metav1.OwnerReference{}
+					}
+					return fetched.ObjectMeta.OwnerReferences
+				}, 5).Should(Not(BeEmpty()))
 			})
 		})
 	})
@@ -232,6 +441,8 @@ var _ = Describe("permission-controller", func() {
 						Name:      "example-rabbit",
 						Namespace: "default",
 					},
+					User:  "example",
+					Vhost: "example",
 				},
 			}
 		})
@@ -267,6 +478,8 @@ var _ = Describe("permission-controller", func() {
 						Name:      "example-rabbit",
 						Namespace: "default",
 					},
+					User:  "example",
+					Vhost: "example",
 				},
 			}
 			fakeRabbitMQClient.UpdatePermissionsInReturns(&http.Response{
@@ -305,6 +518,8 @@ var _ = Describe("permission-controller", func() {
 						Name:      "allow-all-rabbit",
 						Namespace: "default",
 					},
+					User:  "example",
+					Vhost: "example",
 				},
 			}
 			fakeRabbitMQClient.UpdatePermissionsInReturns(&http.Response{

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -966,6 +966,7 @@ UserStatus defines the observed state of User.
 | *`observedGeneration`* __integer__ | observedGeneration is the most recent successful generation observed for this User. It corresponds to the User's generation, which is updated on mutation by the API Server.
 | *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-condition[$$Condition$$] array__ | 
 | *`credentials`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Provides a reference to a Secret object containing the user credentials.
+| *`username`* __string__ | Provide rabbitmq Username
 |===
 
 


### PR DESCRIPTION
Ref #324 

## Summary Of Changes

In permission controller:
- add owner reference from User on Permission when userReference is set
- add condition: when the User doesn’t exist and Permission is in deletion status, we skip the permission removal

In user controller:
- set in the User status part a field with the real username to not depend on the secret

