### PR TITLE
Ensure consistent log format

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"k8s.io/klog/v2"
 	"os"
 	"regexp"
 	"strings"
@@ -73,7 +74,9 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(logger)
+	klog.SetLogger(logger.WithName("messaging-topology-operator"))
 
 	operatorNamespace := os.Getenv(controllers.OperatorNamespaceEnvVar)
 	if operatorNamespace == "" {

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 
 	logger := zap.New(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(logger)
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1420#issuecomment-794525248
 	klog.SetLogger(logger.WithName("messaging-topology-operator"))
 
 	operatorNamespace := os.Getenv(controllers.OperatorNamespaceEnvVar)


### PR DESCRIPTION
This closes #295 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
Set the LogSink for the klog logger used by client-go to the same as the controller-runtime zap logger

## Additional Context
See https://github.com/rabbitmq/messaging-topology-operator/issues/295#issuecomment-1060631658
