### PR TITLE
Add all crds to 'rabbitmq' category

### DIFF
--- a/api/v1alpha1/superstream_types.go
+++ b/api/v1alpha1/superstream_types.go
@@ -49,7 +49,7 @@ type SuperStreamStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // SuperStream is the Schema for the queues API

--- a/api/v1beta1/binding_types.go
+++ b/api/v1beta1/binding_types.go
@@ -53,7 +53,7 @@ type BindingStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Binding is the Schema for the bindings API

--- a/api/v1beta1/exchange_types.go
+++ b/api/v1beta1/exchange_types.go
@@ -49,7 +49,7 @@ type ExchangeStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Exchange is the Schema for the exchanges API

--- a/api/v1beta1/federation_types.go
+++ b/api/v1beta1/federation_types.go
@@ -47,7 +47,7 @@ type FederationStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Federation is the Schema for the federations API

--- a/api/v1beta1/permission_types.go
+++ b/api/v1beta1/permission_types.go
@@ -46,7 +46,7 @@ type PermissionStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Permission is the Schema for the permissions API

--- a/api/v1beta1/policy_types.go
+++ b/api/v1beta1/policy_types.go
@@ -49,7 +49,7 @@ type PolicyStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Policy is the Schema for the policies API

--- a/api/v1beta1/queue_types.go
+++ b/api/v1beta1/queue_types.go
@@ -53,7 +53,7 @@ type QueueStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Queue is the Schema for the queues API

--- a/api/v1beta1/shovel_types.go
+++ b/api/v1beta1/shovel_types.go
@@ -60,7 +60,7 @@ type ShovelStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Shovel is the Schema for the shovels API

--- a/api/v1beta1/user_types.go
+++ b/api/v1beta1/user_types.go
@@ -53,7 +53,7 @@ type UserTag string
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // User is the Schema for the users API.

--- a/api/v1beta1/vhost_types.go
+++ b/api/v1beta1/vhost_types.go
@@ -37,7 +37,7 @@ type VhostStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
+// +kubebuilder:resource:categories=all;rabbitmq
 // +kubebuilder:subresource:status
 
 // Vhost is the Schema for the vhosts API

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: bindings.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Binding
     listKind: BindingList
     plural: bindings

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: exchanges.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Exchange
     listKind: ExchangeList
     plural: exchanges

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federations.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Federation
     listKind: FederationList
     plural: federations

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: permissions.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Permission
     listKind: PermissionList
     plural: permissions

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: policies.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Policy
     listKind: PolicyList
     plural: policies

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: queues.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Queue
     listKind: QueueList
     plural: queues

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: schemareplications.rabbitmq.com
 spec:

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: shovels.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Shovel
     listKind: ShovelList
     plural: shovels

--- a/config/crd/bases/rabbitmq.com_superstreams.yaml
+++ b/config/crd/bases/rabbitmq.com_superstreams.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: superstreams.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: SuperStream
     listKind: SuperStreamList
     plural: superstreams

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: users.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: User
     listKind: UserList
     plural: users

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: vhosts.rabbitmq.com
 spec:
@@ -12,6 +11,7 @@ spec:
   names:
     categories:
     - all
+    - rabbitmq
     kind: Vhost
     listKind: VhostList
     plural: vhosts

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

For convenience, this adds all crds to category `rabbitmq` (PR that does the same to rabbitmqcluster: https://github.com/rabbitmq/cluster-operator/pull/984 ). 

So When you do `kubectl get rabbitmq`, you see:
```
❯ k get rabbitmq
NAME                            AGE
queue.rabbitmq.com/qq-example   8m26s

NAME                                  ALLREPLICASREADY   RECONCILESUCCESS   AGE
rabbitmqcluster.rabbitmq.com/sample   True               True               13m

NAME                            AGE
user.rabbitmq.com/user-sample   5m10s

... and all other rabbitmq resouces
```


## Additional Context
