### PR TITLE
Validate Quorum queue settings in WebHook

### DIFF
--- a/api/v1beta1/queue_webhook.go
+++ b/api/v1beta1/queue_webhook.go
@@ -22,6 +22,11 @@ var _ webhook.Validator = &Queue{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 // either rabbitmqClusterReference.name or rabbitmqClusterReference.connectionSecret must be provided but not both
 func (q *Queue) ValidateCreate() error {
+	if q.Spec.Type == "quorum" && q.Spec.Durable == false {
+		return apierrors.NewForbidden(q.GroupResource(), q.Name,
+			field.Forbidden(field.NewPath("spec", "durable"),
+				"Quorum queues must have durable set to true"))
+	}
 	return q.Spec.RabbitmqClusterReference.ValidateOnCreate(q.GroupResource(), q.Name)
 }
 

--- a/api/v1beta1/queue_webhook_test.go
+++ b/api/v1beta1/queue_webhook_test.go
@@ -39,6 +39,12 @@ var _ = Describe("queue webhook", func() {
 			notAllowedQ.Spec.RabbitmqClusterReference.ConnectionSecret = nil
 			Expect(apierrors.IsForbidden(notAllowedQ.ValidateCreate())).To(BeTrue())
 		})
+
+		It("does not allow non-durable quorum queues", func() {
+			notAllowedQ := queue.DeepCopy()
+			notAllowedQ.Spec.AutoDelete = false
+			Expect(apierrors.IsForbidden(notAllowedQ.ValidateCreate())).To(BeTrue(), "Expected 'forbidden' response for non-durable quorum queue")
+		})
 	})
 
 	Context("ValidateUpdate", func() {


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
We were allowing non-durable quorum queues as a valid manifest. This results in a 400
response from RabbitMQ server. The error is not visible to the user,
until they describe the queue and observe the status condition. Now it
fails sooner, which is good given that we know these settings will never
succeed.

