### PR TITLE
Temporary fix on deletion_system_test in order to avoid to create a m…

### DIFF
--- a/system_tests/deletion_system_test.go
+++ b/system_tests/deletion_system_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Deletion", func() {
 			},
 			Spec: topology.PolicySpec{
 				Name:    "policy-deletion-test",
-				Pattern: ".*",
+				Pattern: "not-match-queue",
 				ApplyTo: "queues",
 				Definition: &runtime.RawExtension{
 					Raw: []byte(`{"ha-mode":"all"}`),

--- a/system_tests/deletion_system_test.go
+++ b/system_tests/deletion_system_test.go
@@ -26,6 +26,8 @@ var _ = Describe("Deletion", func() {
 
 	BeforeEach(func() {
 		targetCluster = basicTestRabbitmqCluster("to-be-deleted", namespace)
+		var DeletionGracePeriod int64 = 10
+		targetCluster.Spec.TerminationGracePeriodSeconds = &DeletionGracePeriod
 		setupTestRabbitmqCluster(k8sClient, targetCluster)
 		targetClusterRef := topology.RabbitmqClusterReference{Name: targetCluster.Name}
 		exchange = topology.Exchange{
@@ -45,7 +47,7 @@ var _ = Describe("Deletion", func() {
 			},
 			Spec: topology.PolicySpec{
 				Name:    "policy-deletion-test",
-				Pattern: "not-match-queue",
+				Pattern: ".*",
 				ApplyTo: "queues",
 				Definition: &runtime.RawExtension{
 					Raw: []byte(`{"ha-mode":"all"}`),

--- a/system_tests/deletion_system_test.go
+++ b/system_tests/deletion_system_test.go
@@ -7,6 +7,7 @@ import (
 	topology "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,8 +27,7 @@ var _ = Describe("Deletion", func() {
 
 	BeforeEach(func() {
 		targetCluster = basicTestRabbitmqCluster("to-be-deleted", namespace)
-		var DeletionGracePeriod int64 = 10
-		targetCluster.Spec.TerminationGracePeriodSeconds = &DeletionGracePeriod
+		targetCluster.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(10)
 		setupTestRabbitmqCluster(k8sClient, targetCluster)
 		targetClusterRef := topology.RabbitmqClusterReference{Name: targetCluster.Name}
 		exchange = topology.Exchange{


### PR DESCRIPTION
…irror queue in a one pod cluster causing the pod to get stuck in "terminating" phase and preventing our pipeline to work.

It can be reverted once await_online_synchronized_mirror get fixed to manage this case

Not really a temporary fix anymore, putting grace period to a lower value will increase the stability of this test in general, as the scope is to delete objects when the rabbimq cluster get deleted.

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

## Additional Context
