### PR TITLE
Support connecting Vault with TLS and check rabbitmqcluster status

### DIFF
--- a/internal/cluster_reference_test.go
+++ b/internal/cluster_reference_test.go
@@ -114,7 +114,7 @@ var _ = Describe("ParseRabbitmqClusterReference", func() {
 
 			It("errors", func() {
 				_, _, err := internal.ParseRabbitmqClusterReference(ctx, fakeClient, topology.RabbitmqClusterReference{Name: existingRabbitMQCluster.Name}, existingRabbitMQCluster.Namespace, "")
-				Expect(err).To(MatchError("RabbitmqCluster has no ServiceReference set in status.defaultUser"))
+				Expect(err).To(MatchError(internal.NoServiceReferenceSetError))
 			})
 		})
 
@@ -207,7 +207,7 @@ var _ = Describe("ParseRabbitmqClusterReference", func() {
 
 				It("errors", func() {
 					_, _, err := internal.ParseRabbitmqClusterReference(ctx, fakeClient, topology.RabbitmqClusterReference{Name: existingRabbitMQCluster.Name}, existingRabbitMQCluster.Namespace, "")
-					Expect(err).To(MatchError("RabbitmqCluster has no ServiceReference set in status.defaultUser"))
+					Expect(err).To(MatchError(internal.NoServiceReferenceSetError))
 				})
 			})
 		})

--- a/internal/vault_reader.go
+++ b/internal/vault_reader.go
@@ -74,7 +74,7 @@ func InitializeClient() func() {
 		}
 
 		config := vault.DefaultConfig() // modify for more granular configuration
-		
+
 		if strings.HasPrefix(vaultURL, "https") {
 			systemCertPool, err := x509.SystemCertPool()
 			if err != nil {

--- a/internal/vault_reader.go
+++ b/internal/vault_reader.go
@@ -1,9 +1,12 @@
 package internal
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,7 +66,24 @@ func GetSecretStoreClient() (SecretStoreClient, error) {
 func InitializeClient() func() {
 	return func() {
 		// VAULT_ADDR environment variable will be the address that pod uses to communicate with Vault.
+		// returns error when not set
+		vaultURL := os.Getenv("VAULT_ADDR")
+		if vaultURL == "" {
+			SecretClientCreationError = fmt.Errorf("VAULT_ADDR environment variable not set; cannot initialize vault client")
+			return
+		}
+
 		config := vault.DefaultConfig() // modify for more granular configuration
+		
+		if strings.HasPrefix(vaultURL, "https") {
+			systemCertPool, err := x509.SystemCertPool()
+			if err != nil {
+				SecretClientCreationError = fmt.Errorf("failed to retrieve system trusted certs: %w", err)
+				return
+			}
+			config.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs = systemCertPool
+		}
+
 		vaultClient, err := vault.NewClient(config)
 		if err != nil {
 			SecretClientCreationError = fmt.Errorf("unable to initialize Vault client: %w", err)

--- a/internal/vault_reader_test.go
+++ b/internal/vault_reader_test.go
@@ -300,11 +300,12 @@ var _ = Describe("VaultReader", func() {
 			vaultSpec                  *rabbitmqv1beta1.VaultSpec
 			getSecretStoreClientTester func(vaultSpec *rabbitmqv1beta1.VaultSpec) (internal.SecretStoreClient, error)
 		)
+		BeforeEach(func() {
+			os.Setenv("VAULT_ADDR", "vault-address")
+		})
 
 		When("vault role is not set in the environment", func() {
-			var (
-				vaultRoleUsedForLogin string
-			)
+			var vaultRoleUsedForLogin string
 
 			BeforeEach(func() {
 				internal.FirstLoginAttemptResultCh = make(chan error, 1)
@@ -528,6 +529,14 @@ var _ = Describe("VaultReader", func() {
 
 			It("should return a secret store client", func() {
 				Expect(secretStoreClient).ToNot(BeNil())
+			})
+		})
+
+		When("VAULT_ADDR is not set", func() {
+			It("returns an error", func() {
+				os.Unsetenv("VAULT_ADDR")
+				secretStoreClient, err = getSecretStoreClientTester(vaultSpec)
+				Expect(err).To(MatchError("VAULT_ADDR environment variable not set; cannot initialize vault client"))
 			})
 		})
 	})


### PR DESCRIPTION
This is related to #315

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

To be able to connect to Vault successfully, [PR 1031 from cluster operator](https://github.com/rabbitmq/cluster-operator/pull/1031) needs to be merged and released first, so this PR won't fix the original issue just yet.

- check if rabbitmq status.defaultUser is set when vault is used as well
- provide system certs pool when vault address scheme is set to `https`
- error when vault address environment variable is not set when initializing vault client

## Additional Context
