### PR TITLE
Support setting manager sync period using operator envVar

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -39,6 +39,7 @@ const (
 	KubernetesInternalDomainEnvVar = "MESSAGING_DOMAIN_NAME"
 	OperatorNamespaceEnvVar        = "OPERATOR_NAMESPACE"
 	EnableWebhooksEnvVar           = "ENABLE_WEBHOOKS"
+	ControllerSyncPeriodEnvVar     = "SYNC_PERIOD"
 )
 
 type TopologyController interface {


### PR DESCRIPTION
This closes #243

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- manager sync period configuration is for all controllers under the same manager
- SYNC_PERIOD won't have a default, user need to op in for this behavior as we cannot determine a reasonable default
- SYNC_PERIOD needs to be in a format that's parsable by time.ParseDuration(), else exit 1. When successfully parsed, the operator logs at starting, e.g.`{"level":"info","ts":1652354704.2477453,"logger":"setup","msg":"sync period set; all resources will be reconciled every: 5m0s"}`
- can be updated like any other env var

## Additional Context

[same functionality in crossplane](https://github.com/crossplane/crossplane/blob/1344a86018f03fcbba6b9365c63696dcd47ebcf6/cmd/crossplane/core/core.go#L71)
[discussion in controller runtime](https://github.com/kubernetes-sigs/controller-runtime/issues/521)
