### PR TITLE
Setup vaultSpec and tester to avoid test panic

### DIFF
--- a/rabbitmqclient/vault_reader_test.go
+++ b/rabbitmqclient/vault_reader_test.go
@@ -533,6 +533,15 @@ var _ = Describe("VaultReader", func() {
 		})
 
 		When("VAULT_ADDR is not set", func() {
+			BeforeEach(func() {
+				vaultSpec = &rabbitmqv1beta1.VaultSpec{
+					DefaultUserPath: "a-path",
+				}
+				getSecretStoreClientTester = func(vaultSpec *rabbitmqv1beta1.VaultSpec) (rabbitmqclient.SecretStoreClient, error) {
+					rabbitmqclient.InitializeClient()()
+					return rabbitmqclient.SecretClient, rabbitmqclient.SecretClientCreationError
+				}
+			})
 			It("returns an error", func() {
 				os.Unsetenv("VAULT_ADDR")
 				secretStoreClient, err = getSecretStoreClientTester(vaultSpec)


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Reported by @Zerpet that in When("VAULT_ADDR is not set"), it should set up its own vaultSpec and getSecretStoreClientTester() implementations. This was flaky since it only fails when this test was run before any of the other vault specs.

Example: https://hush-house.pivotal.io/teams/rabbitmq-for-kubernetes/pipelines/messaging-topology-operator/jobs/unit-tests/builds/223

```
------------------------------
•! [PANICKED] [0.000 seconds]
VaultReader Initialize secret store client when VAULT_ADDR is not set [It] returns an error
/Users/clyu/workspace/messaging-topology-operator/rabbitmqclient/vault_reader_test.go:536

  Test Panicked
  In [It] at: /Users/clyu/.gimme/versions/go1.17.7.darwin.amd64/src/runtime/panic.go:221

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/rabbitmq/messaging-topology-operator/rabbitmqclient_test.glob..func4.2.7.1()
    	/Users/clyu/workspace/messaging-topology-operator/rabbitmqclient/vault_reader_test.go:538 +0x56
```

## Additional Context
