### PR TITLE
Better fields descriptions

### DIFF
--- a/api/v1beta1/schemareplication_types.go
+++ b/api/v1beta1/schemareplication_types.go
@@ -30,24 +30,21 @@ type SchemaReplicationSpec struct {
 	// When endpoints are provided in both spec.endpoints and spec.upstreamSecret, spec.endpoints takes
 	// precedence.
 	Endpoints string `json:"endpoints,omitempty"`
-	// Secret backend configuration for the RabbitmqCluster.
-	// Enables to fetch default user credentials and certificates from K8s external secret stores.
+	// Set to fetch user credentials from K8s external secret stores to be used for schema replication.
 	SecretBackend SecretBackend `json:"secretBackend,omitempty"`
 }
 
 // SecretBackend configures a single secret backend.
 // Today, only Vault exists as supported secret backend.
-// Future secret backends could be Secrets Store CSI Driver.
-// If not configured, K8s Secrets will be used.
 type SecretBackend struct {
 	Vault *VaultSpec `json:"vault,omitempty"`
 }
 
 type VaultSpec struct {
-	// Path in Vault to access a KV (Key-Value) secret with the fields username and password to be used for schema replication.
+	// Path in Vault to access a KV (Key-Value) secret with the fields username and password to be used for replication.
 	// For example "secret/data/rabbitmq/config".
-	// Optional; if not provided, username and password will come from spec.upstreamSecret.
-	// Have to set either secretBackend.vault.secretPath or spec.upstreamSecret, but not both.
+	// Optional; if not provided, username and password will come from upstreamSecret instead.
+	// Have to set either secretBackend.vault.secretPath or upstreamSecret, but not both.
 	SecretPath string `json:"secretPath,omitempty"`
 }
 

--- a/api/v1beta1/schemareplication_webhook_test.go
+++ b/api/v1beta1/schemareplication_webhook_test.go
@@ -97,7 +97,7 @@ var _ = Describe("schema-replication webhook", func() {
 			Expect(updated.ValidateUpdate(&replication)).To(Succeed())
 		})
 
-		It("allows updates on rabbitmqClusterReference.connectionSecret", func() {
+		It("does not allow updates on rabbitmqClusterReference.connectionSecret", func() {
 			connectionScr := SchemaReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-replication",

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -68,19 +68,18 @@ spec:
                     type: string
                 type: object
               secretBackend:
-                description: Secret backend configuration for the RabbitmqCluster.
-                  Enables to fetch default user credentials and certificates from
-                  K8s external secret stores.
+                description: Set to fetch user credentials from K8s external secret
+                  stores to be used for schema replication.
                 properties:
                   vault:
                     properties:
                       secretPath:
                         description: Path in Vault to access a KV (Key-Value) secret
-                          with the fields username and password to be used for schema
-                          replication. For example "secret/data/rabbitmq/config".
-                          Optional; if not provided, username and password will come
-                          from spec.upstreamSecret. Have to set either secretBackend.vault.secretPath
-                          or spec.upstreamSecret, but not both.
+                          with the fields username and password to be used for replication.
+                          For example "secret/data/rabbitmq/config". Optional; if
+                          not provided, username and password will come from upstreamSecret
+                          instead. Have to set either secretBackend.vault.secretPath
+                          or upstreamSecret, but not both.
                         type: string
                     type: object
                 type: object

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -766,7 +766,7 @@ SchemaReplicationSpec defines the desired state of SchemaReplication
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that schema replication would be set for. Must be an existing cluster.
 | *`upstreamSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Defines a Secret which contains credentials to be used for schema replication. The Secret must contain the keys `username` and `password` in its Data field, or operator will error. Have to set either secretBackend.vault.secretPath or spec.upstreamSecret, but not both.
 | *`endpoints`* __string__ | endpoints should be one or multiple endpoints separated by ','. Must provide either spec.endpoints or endpoints in spec.upstreamSecret. When endpoints are provided in both spec.endpoints and spec.upstreamSecret, spec.endpoints takes precedence.
-| *`secretBackend`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-secretbackend[$$SecretBackend$$]__ | Secret backend configuration for the RabbitmqCluster. Enables to fetch default user credentials and certificates from K8s external secret stores.
+| *`secretBackend`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-secretbackend[$$SecretBackend$$]__ | Set to fetch user credentials from K8s external secret stores to be used for schema replication.
 |===
 
 
@@ -791,7 +791,7 @@ SchemaReplicationStatus defines the observed state of SchemaReplication
 [id="{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-secretbackend"]
 ==== SecretBackend 
 
-SecretBackend configures a single secret backend. Today, only Vault exists as supported secret backend. Future secret backends could be Secrets Store CSI Driver. If not configured, K8s Secrets will be used.
+SecretBackend configures a single secret backend. Today, only Vault exists as supported secret backend.
 
 .Appears In:
 ****
@@ -1013,7 +1013,7 @@ UserTag defines the level of access to the management UI allocated to the user. 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`secretPath`* __string__ | Path in Vault to access a KV (Key-Value) secret with the fields username and password to be used for schema replication. For example "secret/data/rabbitmq/config". Optional; if not provided, username and password will come from spec.upstreamSecret. Have to set either secretBackend.vault.secretPath or spec.upstreamSecret, but not both.
+| *`secretPath`* __string__ | Path in Vault to access a KV (Key-Value) secret with the fields username and password to be used for replication. For example "secret/data/rabbitmq/config". Optional; if not provided, username and password will come from upstreamSecret instead. Have to set either secretBackend.vault.secretPath or upstreamSecret, but not both.
 |===
 
 


### PR DESCRIPTION
PR as part of issue: https://github.com/rabbitmq/service-operator-experience/issues/64

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Two small changes

- more general fields descriptions on SecretBackend so it can be reused in standby replication operator
- correct a unit tests description

## Additional Context
