### PR TITLE
Remove hardcoded rmq image from sys tests

### DIFF
--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -180,7 +180,6 @@ func basicTestRabbitmqCluster(name, namespace string) *rabbitmqv1beta1.RabbitmqC
 			Namespace: namespace,
 		},
 		Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-			Image:    "rabbitmq:3.9-management",
 			Replicas: pointer.Int32Ptr(1),
 			Resources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Remove hardcoded rmq image from system tests. I don't think topology operator should have a hardcoded rmq version to test against. Tests can deploy the default image value from cluster operator (currently latest `3.10`).

## Additional Context
