### PR TITLE
Update PR workflow to use latest k8s

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,22 +23,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.19.11, v1.21.1]
+        k8s: [v1.22.9, v1.24.1]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.16.0' # Require Go 1.16 and above, but lower than Go 2.0.0
+        go-version: '^1.17.0' # Require Go 1.16 and above, but lower than Go 2.0.0
     - name: System tests
       env:
         K8S_VERSION: ${{ matrix.k8s }}
       run: |
         export GOPATH="$HOME/go"
         export PATH="$PATH:$GOPATH/bin"
-        make install-tools
+        make install-tools cmctl
         kind create cluster --image kindest/node:"$K8S_VERSION"
-        make cert-manager
-        make cluster-operator
+        make cert-manager cluster-operator
         DOCKER_REGISTRY_SERVER=local-server OPERATOR_IMAGE=local-operator make deploy-kind BUILD_KIT=docker
         make system-tests BUILD_KIT=docker

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ cover.out
 tags
 releases/
 testbin/
+bin/
+tmp/
 *.iml


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- Update Kubernetes version to latest available and lowest supported (N-2) 
- Match Go version with our `go.mod`
- Check cert-manager api readiness before deploying Top-Op

## Additional Context

Cert Manager Pods may become ready before Cert Manager API is ready. This results in a failed Top-Op deployment with an error like `x509: certificate signed by unknown authority`. The workaround is to check and wait for Cert Manager API to become ready.