### PR TITLE
Add top op user object update limitation

### DIFF
--- a/docs/examples/users/README.md
+++ b/docs/examples/users/README.md
@@ -1,0 +1,7 @@
+# User examples
+
+This section contains 3 examples for creating RabbitMQ users.
+Messaging Topology Operator creates users with generated credentials by default. To create RabbitMQ users with provided credentials, you can reference a kubernetes secret object contains keys `username` and `password` in its Data field.
+See [userPreDefinedCreds.yaml](./userPreDefinedCreds.yaml) and [publish-consume-user.yaml](./publish-consume-user.yaml) as examples.
+Note that Messaging Topology Operator does not watch the provided secret and updating the secret object won't update actual user credentials.
+If you wish to update user credentials, you can update the secret and then add a label or annotation to the User object to trigger a Reconile loop.

--- a/docs/examples/users/publish-consume-user.yaml
+++ b/docs/examples/users/publish-consume-user.yaml
@@ -5,8 +5,8 @@ metadata:
   name: test-user-credentials
 type: Opaque
 stringData:
-  username: test-user
-  password: verysecurepw
+  username: test-user # Note that Messaging Topology Operator does not watch this secret. Updating this secret object won't update actual user credentials.
+  password: verysecurepw # As a workaround, you can add a label or annotation to the User object to trigger a Reconile loop and credentials will be updated.
 ---
 apiVersion: rabbitmq.com/v1beta1
 kind: User

--- a/docs/examples/users/userPreDefinedCreds.yaml
+++ b/docs/examples/users/userPreDefinedCreds.yaml
@@ -4,8 +4,8 @@ metadata:
   name: credentials-secret
 type: Opaque
 stringData:
-  username: import-user-sample
-  password: whyareyoulookinghere
+  username: import-user-sample # Note that Messaging Topology Operator does not watch this secret. Updating this secret object won't update actual user credentials.
+  password: whyareyoulookinghere # As a workaround, you can add a label or annotation to the User object to trigger a Reconile loop and credentials will be updated.
 ---
 apiVersion: rabbitmq.com/v1beta1
 kind: User

--- a/docs/examples/vault-support/README.md
+++ b/docs/examples/vault-support/README.md
@@ -20,7 +20,7 @@ Topology Operator uses the first approach (Direct API).
 
 ## Vault-related configuration required
 
-The Vault server must have the version 2 key value secret engine and the 
+The Vault server must have the version 2 key value secret engine and the
 [Vault Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes)
 enabled.
 


### PR DESCRIPTION
This relates #414 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
Document behavior of `users.rabbitmq.com` that updating provided secret won't update the actual credentials.
Related PR to rabbitmq website: https://github.com/rabbitmq/rabbitmq-website/pull/1448

## Additional Context
