### PR TITLE
Go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ Please read [contribution guidelines](CONTRIBUTING.md) if you are interested in 
 ## Copyright
 
 Copyright 2021-2022 VMware, Inc. All Rights Reserved.
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/rabbitmq/messaging-topology-operator)](https://goreportcard.com/report/github.com/rabbitmq/messaging-topology-operator)

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -84,7 +84,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if user.Status.Username != "" {
 			return ctrl.Result{}, r.deleteUser(ctx, rabbitClient, user)
 		} else {
-			// Old function, kept for compatiblity
+			// Old function, kept for compatibility
 			return ctrl.Result{}, r.deleteUserFromSecret(ctx, rabbitClient, user)
 		}
 	}


### PR DESCRIPTION
## Summary Of Changes

Fixes typo found by go report card
Adds go report card status badge

https://goreportcard.com/report/github.com/rabbitmq/messaging-topology-operator