### PR TITLE
Small tests updates

### DIFF
--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: bindings.rabbitmq.com
 spec:
@@ -66,6 +66,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: exchanges.rabbitmq.com
 spec:
@@ -65,6 +65,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: federations.rabbitmq.com
 spec:
@@ -75,6 +75,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.
@@ -98,6 +99,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               vhost:
                 default: /
                 description: Default to vhost '/'; cannot be updated

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: permissions.rabbitmq.com
 spec:
@@ -64,6 +64,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.
@@ -87,6 +88,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               vhost:
                 description: Name of an existing vhost; required property; cannot
                   be updated

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: policies.rabbitmq.com
 spec:
@@ -79,6 +79,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: queues.rabbitmq.com
 spec:
@@ -70,6 +70,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.

--- a/config/crd/bases/rabbitmq.com_schemareplications.yaml
+++ b/config/crd/bases/rabbitmq.com_schemareplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: schemareplications.rabbitmq.com
 spec:
@@ -58,6 +58,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.
@@ -95,6 +96,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
             required:
             - rabbitmqClusterReference
             type: object

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: shovels.rabbitmq.com
 spec:
@@ -89,6 +89,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.
@@ -125,6 +126,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               vhost:
                 default: /
                 description: Default to vhost '/'; cannot be updated

--- a/config/crd/bases/rabbitmq.com_superstreams.yaml
+++ b/config/crd/bases/rabbitmq.com_superstreams.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: superstreams.rabbitmq.com
 spec:
@@ -61,6 +61,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: users.rabbitmq.com
 spec:
@@ -52,6 +52,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               rabbitmqClusterReference:
                 description: Reference to the RabbitmqCluster that the user will be
                   created for. This cluster must exist for the User object to be created.
@@ -67,6 +68,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.
@@ -134,6 +136,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               observedGeneration:
                 description: observedGeneration is the most recent successful generation
                   observed for this User. It corresponds to the User's generation,

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: vhosts.rabbitmq.com
 spec:
@@ -56,6 +56,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     description: The name of the RabbitMQ cluster to reference. Have
                       to set either name or connectionSecret, but not both.

--- a/controllers/binding_controller_test.go
+++ b/controllers/binding_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,110 +22,89 @@ var _ = Describe("bindingController", func() {
 	var binding topology.Binding
 	var bindingName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			binding = topology.Binding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      bindingName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		binding = topology.Binding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bindingName,
+				Namespace: "default",
+			},
+			Spec: topology.BindingSpec{
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-				Spec: topology.BindingSpec{
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
-				},
-			}
-		})
+			},
+		}
+	})
 
-		When("creating a binding", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					bindingName = "test-binding-http-error"
-					fakeRabbitMQClient.DeclareBindingReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("some HTTP error"))
-				})
-
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &binding)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
-							&binding,
-						)
-
-						return binding.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some HTTP error"),
-					})))
-				})
+	When("creating a binding", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				bindingName = "test-binding-http-error"
+				fakeRabbitMQClient.DeclareBindingReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("some HTTP error"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					bindingName = "test-binding-go-error"
-					fakeRabbitMQClient.DeclareBindingReturns(nil, errors.New("hit a exception"))
-				})
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &binding)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
+						&binding,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &binding)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
-							&binding,
-						)
-
-						return binding.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("hit a exception"),
-					})))
-				})
-			})
-
-			When("the RabbitMQ Client successfully creates a binding", func() {
-				BeforeEach(func() {
-					bindingName = "test-binding-success"
-					fakeRabbitMQClient.DeclareBindingReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition to indicate a success in reconciling", func() {
-					Expect(client.Create(ctx, &binding)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
-							&binding,
-						)
-
-						return binding.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return binding.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some HTTP error"),
+				})))
 			})
 		})
 
-		When("Deleting a binding", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				bindingName = "test-binding-go-error"
+				fakeRabbitMQClient.DeclareBindingReturns(nil, errors.New("hit a exception"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &binding)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
+						&binding,
+					)
+
+					return binding.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("hit a exception"),
+				})))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				bindingName = "test-binding-success"
 				fakeRabbitMQClient.DeclareBindingReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &binding)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&binding)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.bindings.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -139,81 +119,86 @@ var _ = Describe("bindingController", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					bindingName = "delete-binding-http-error"
-					fakeRabbitMQClient.DeleteBindingReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	When("Deleting a binding", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.DeclareBindingReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &binding)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
+					&binding,
+				)
 
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &binding)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &topology.Binding{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete binding"))
-				})
+				return binding.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				bindingName = "delete-binding-http-error"
+				fakeRabbitMQClient.DeleteBindingReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					bindingName = "delete-binding-go-error"
-					fakeRabbitMQClient.DeleteBindingReturns(nil, errors.New("some error"))
-				})
-
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &binding)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &topology.Binding{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete binding"))
-				})
-			})
-
-			When("the RabbitMQ Client successfully deletes a binding", func() {
-				BeforeEach(func() {
-					bindingName = "delete-binding-success"
-					fakeRabbitMQClient.DeleteBindingReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("raises an event to indicate a successful deletion", func() {
-					Expect(client.Delete(ctx, &binding)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &topology.Binding{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete binding")),
-						ContainElement("Normal SuccessfulDelete successfully deleted binding"),
-					))
-				})
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &binding)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &topology.Binding{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete binding"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				bindingName = "finalizer-test"
+				bindingName = "delete-binding-go-error"
+				fakeRabbitMQClient.DeleteBindingReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &binding)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.Binding
-					err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.bindings.rabbitmq.com"))
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &binding)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &topology.Binding{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete binding"))
+			})
+		})
+
+		When("the RabbitMQ Client successfully deletes a binding", func() {
+			BeforeEach(func() {
+				bindingName = "delete-binding-success"
+				fakeRabbitMQClient.DeleteBindingReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("raises an event to indicate a successful deletion", func() {
+				Expect(client.Delete(ctx, &binding)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, &topology.Binding{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete binding")),
+					ContainElement("Normal SuccessfulDelete successfully deleted binding"),
+				))
 			})
 		})
 	})

--- a/controllers/federation_controller_test.go
+++ b/controllers/federation_controller_test.go
@@ -21,113 +21,99 @@ var _ = Describe("federation-controller", func() {
 	var federation topology.Federation
 	var federationName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			federation = topology.Federation{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      federationName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		federation = topology.Federation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      federationName,
+				Namespace: "default",
+			},
+			Spec: topology.FederationSpec{
+				Name:      "my-federation-upstream",
+				Vhost:     "/test",
+				UriSecret: &corev1.LocalObjectReference{Name: "federation-uri"},
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-				Spec: topology.FederationSpec{
-					Name:      "my-federation-upstream",
-					Vhost:     "/test",
-					UriSecret: &corev1.LocalObjectReference{Name: "federation-uri"},
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
-				},
-			}
-		})
+			},
+		}
+	})
 
-		When("creation", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					federationName = "test-federation-http-error"
-					fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("some HTTP error"))
-				})
-
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &federation)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace},
-							&federation,
-						)
-
-						return federation.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some HTTP error"),
-					})))
-				})
+	When("creation", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				federationName = "test-federation-http-error"
+				fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("some HTTP error"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					federationName = "test-federation-go-error"
-					fakeRabbitMQClient.PutFederationUpstreamReturns(nil, errors.New("some go failure here"))
-				})
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &federation)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace},
+						&federation,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &federation)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace},
-							&federation,
-						)
-
-						return federation.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some go failure here"),
-					})))
-				})
-			})
-
-			Context("success", func() {
-				BeforeEach(func() {
-					federationName = "test-federation-success"
-					fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition 'Ready' to 'true'", func() {
-					Expect(client.Create(ctx, &federation)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace},
-							&federation,
-						)
-
-						return federation.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return federation.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some HTTP error"),
+				})))
 			})
 		})
 
-		When("deletion", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				federationName = "test-federation-go-error"
+				fakeRabbitMQClient.PutFederationUpstreamReturns(nil, errors.New("some go failure here"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &federation)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace},
+						&federation,
+					)
+
+					return federation.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some go failure here"),
+				})))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				federationName = "test-federation-success"
 				fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &federation)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(func() []string {
+					var fetched topology.Federation
+					err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &fetched)
+					if err != nil {
+						return []string{}
+					}
+					return fetched.ObjectMeta.Finalizers
+				}, 5).Should(ConsistOf("deletion.finalizers.federations.rabbitmq.com"))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -142,81 +128,86 @@ var _ = Describe("federation-controller", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					federationName = "delete-federation-http-error"
-					fakeRabbitMQClient.DeleteFederationUpstreamReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	When("deletion", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &federation)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace},
+					&federation,
+				)
 
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &federation)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &topology.Federation{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete federation upstream parameter"))
-				})
+				return federation.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				federationName = "delete-federation-http-error"
+				fakeRabbitMQClient.DeleteFederationUpstreamReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					federationName = "delete-federation-go-error"
-					fakeRabbitMQClient.DeleteFederationUpstreamReturns(nil, errors.New("some error"))
-				})
-
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &federation)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &topology.Federation{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete federation upstream parameter"))
-				})
-			})
-
-			Context("success", func() {
-				BeforeEach(func() {
-					federationName = "delete-federation-success"
-					fakeRabbitMQClient.DeleteFederationUpstreamReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("publishes a normal event", func() {
-					Expect(client.Delete(ctx, &federation)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &topology.Federation{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete federation upstream parameter")),
-						ContainElement("Normal SuccessfulDelete successfully deleted federation upstream parameter"),
-					))
-				})
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &federation)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &topology.Federation{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete federation upstream parameter"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				federationName = "finalizer-test"
+				federationName = "delete-federation-go-error"
+				fakeRabbitMQClient.DeleteFederationUpstreamReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &federation)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.Federation
-					err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.federations.rabbitmq.com"))
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &federation)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &topology.Federation{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete federation upstream parameter"))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				federationName = "delete-federation-success"
+				fakeRabbitMQClient.DeleteFederationUpstreamReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("publishes a normal event", func() {
+				Expect(client.Delete(ctx, &federation)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: federation.Name, Namespace: federation.Namespace}, &topology.Federation{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete federation upstream parameter")),
+					ContainElement("Normal SuccessfulDelete successfully deleted federation upstream parameter"),
+				))
 			})
 		})
 	})

--- a/controllers/policy_controller_test.go
+++ b/controllers/policy_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,113 +24,92 @@ var _ = Describe("policy-controller", func() {
 	var policy topology.Policy
 	var policyName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			policy = topology.Policy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      policyName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		policy = topology.Policy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      policyName,
+				Namespace: "default",
+			},
+			Spec: topology.PolicySpec{
+				Definition: &runtime.RawExtension{
+					Raw: []byte(`{"key":"value"}`),
 				},
-				Spec: topology.PolicySpec{
-					Definition: &runtime.RawExtension{
-						Raw: []byte(`{"key":"value"}`),
-					},
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-			}
-		})
+			},
+		}
+	})
 
-		Context("creation", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					policyName = "test-http-error"
-					fakeRabbitMQClient.PutPolicyReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("a failure"))
-				})
-
-				It("sets the status condition", func() {
-					Expect(client.Create(ctx, &policy)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
-							&policy,
-						)
-
-						return policy.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a failure"),
-					})))
-				})
+	Context("creation", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				policyName = "test-http-error"
+				fakeRabbitMQClient.PutPolicyReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("a failure"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					policyName = "test-go-error"
-					fakeRabbitMQClient.PutPolicyReturns(nil, errors.New("a go failure"))
-				})
+			It("sets the status condition", func() {
+				Expect(client.Create(ctx, &policy)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
+						&policy,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &policy)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
-							&policy,
-						)
-
-						return policy.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a go failure"),
-					})))
-				})
-			})
-
-			When("success", func() {
-				BeforeEach(func() {
-					policyName = "test-create-success"
-					fakeRabbitMQClient.PutPolicyReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition 'Ready' to 'true' ", func() {
-					Expect(client.Create(ctx, &policy)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
-							&policy,
-						)
-
-						return policy.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return policy.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a failure"),
+				})))
 			})
 		})
 
-		Context("deletion", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				policyName = "test-go-error"
+				fakeRabbitMQClient.PutPolicyReturns(nil, errors.New("a go failure"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &policy)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
+						&policy,
+					)
+
+					return policy.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a go failure"),
+				})))
+			})
+		})
+
+		When("success", func() {
+			BeforeEach(func() {
+				policyName = "test-create-success"
 				fakeRabbitMQClient.PutPolicyReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &policy)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&policy)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.policies.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true' ")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -144,81 +124,86 @@ var _ = Describe("policy-controller", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					policyName = "delete-policy-http-error"
-					fakeRabbitMQClient.DeletePolicyReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	Context("deletion", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.PutPolicyReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &policy)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace},
+					&policy,
+				)
 
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &policy)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &topology.Policy{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete policy"))
-				})
+				return policy.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				policyName = "delete-policy-http-error"
+				fakeRabbitMQClient.DeletePolicyReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					policyName = "delete-go-error"
-					fakeRabbitMQClient.DeletePolicyReturns(nil, errors.New("some error"))
-				})
-
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &policy)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &topology.Policy{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete policy"))
-				})
-			})
-
-			When("the RabbitMQ Client successfully deletes a policy", func() {
-				BeforeEach(func() {
-					policyName = "delete-policy-success"
-					fakeRabbitMQClient.DeletePolicyReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("publishes a normal event", func() {
-					Expect(client.Delete(ctx, &policy)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &topology.Policy{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete policy")),
-						ContainElement("Normal SuccessfulDelete successfully deleted policy"),
-					))
-				})
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &policy)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &topology.Policy{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete policy"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				policyName = "finalizer-test"
+				policyName = "delete-go-error"
+				fakeRabbitMQClient.DeletePolicyReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &policy)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.Policy
-					err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.policies.rabbitmq.com"))
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &policy)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &topology.Policy{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete policy"))
+			})
+		})
+
+		When("the RabbitMQ Client successfully deletes a policy", func() {
+			BeforeEach(func() {
+				policyName = "delete-policy-success"
+				fakeRabbitMQClient.DeletePolicyReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("publishes a normal event", func() {
+				Expect(client.Delete(ctx, &policy)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, &topology.Policy{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete policy")),
+					ContainElement("Normal SuccessfulDelete successfully deleted policy"),
+				))
 			})
 		})
 	})

--- a/controllers/queue_controller_test.go
+++ b/controllers/queue_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,110 +22,89 @@ var _ = Describe("queue-controller", func() {
 	var queue topology.Queue
 	var queueName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			queue = topology.Queue{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      queueName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		queue = topology.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      queueName,
+				Namespace: "default",
+			},
+			Spec: topology.QueueSpec{
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-				Spec: topology.QueueSpec{
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
-				},
-			}
-		})
+			},
+		}
+	})
 
-		Context("creation", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					queueName = "test-http-error"
-					fakeRabbitMQClient.DeclareQueueReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("a failure"))
-				})
-
-				It("sets the status condition", func() {
-					Expect(client.Create(ctx, &queue)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace},
-							&queue,
-						)
-
-						return queue.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a failure"),
-					})))
-				})
+	Context("creation", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				queueName = "test-http-error"
+				fakeRabbitMQClient.DeclareQueueReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("a failure"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					queueName = "test-go-error"
-					fakeRabbitMQClient.DeclareQueueReturns(nil, errors.New("a go failure"))
-				})
+			It("sets the status condition", func() {
+				Expect(client.Create(ctx, &queue)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace},
+						&queue,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &queue)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace},
-							&queue,
-						)
-
-						return queue.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a go failure"),
-					})))
-				})
-			})
-
-			When("success", func() {
-				BeforeEach(func() {
-					queueName = "test-create-success"
-					fakeRabbitMQClient.DeclareQueueReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition 'Ready' to 'true' ", func() {
-					Expect(client.Create(ctx, &queue)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace},
-							&queue,
-						)
-
-						return queue.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return queue.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a failure"),
+				})))
 			})
 		})
 
-		Context("deletion", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				queueName = "test-go-error"
+				fakeRabbitMQClient.DeclareQueueReturns(nil, errors.New("a go failure"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &queue)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace},
+						&queue,
+					)
+
+					return queue.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a go failure"),
+				})))
+			})
+		})
+
+		When("success", func() {
+			BeforeEach(func() {
+				queueName = "test-create-success"
 				fakeRabbitMQClient.DeclareQueueReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &queue)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&queue)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.queues.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -139,81 +119,86 @@ var _ = Describe("queue-controller", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					queueName = "delete-queue-http-error"
-					fakeRabbitMQClient.DeleteQueueReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	Context("deletion", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.DeclareQueueReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &queue)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace},
+					&queue,
+				)
 
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &queue)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &topology.Queue{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete queue"))
-				})
+				return queue.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				queueName = "delete-queue-http-error"
+				fakeRabbitMQClient.DeleteQueueReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					queueName = "delete-go-error"
-					fakeRabbitMQClient.DeleteQueueReturns(nil, errors.New("some error"))
-				})
-
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &queue)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &topology.Queue{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete queue"))
-				})
-			})
-
-			When("the RabbitMQ Client successfully deletes a queue", func() {
-				BeforeEach(func() {
-					queueName = "delete-queue-success"
-					fakeRabbitMQClient.DeleteQueueReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("publishes a normal event", func() {
-					Expect(client.Delete(ctx, &queue)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &topology.Queue{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete queue")),
-						ContainElement("Normal SuccessfulDelete successfully deleted queue"),
-					))
-				})
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &queue)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &topology.Queue{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete queue"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				queueName = "finalizer-test"
+				queueName = "delete-go-error"
+				fakeRabbitMQClient.DeleteQueueReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &queue)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.Queue
-					err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.queues.rabbitmq.com"))
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &queue)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &topology.Queue{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete queue"))
+			})
+		})
+
+		When("the RabbitMQ Client successfully deletes a queue", func() {
+			BeforeEach(func() {
+				queueName = "delete-queue-success"
+				fakeRabbitMQClient.DeleteQueueReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("publishes a normal event", func() {
+				Expect(client.Delete(ctx, &queue)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: queue.Name, Namespace: queue.Namespace}, &topology.Queue{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete queue")),
+					ContainElement("Normal SuccessfulDelete successfully deleted queue"),
+				))
 			})
 		})
 	})

--- a/controllers/schemareplication_controller_test.go
+++ b/controllers/schemareplication_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rabbitmq/messaging-topology-operator/rabbitmqclient/rabbitmqclientfakes"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,113 +26,92 @@ var _ = Describe("schema-replication-controller", func() {
 	var replication topology.SchemaReplication
 	var replicationName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			replication = topology.SchemaReplication{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      replicationName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		replication = topology.SchemaReplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      replicationName,
+				Namespace: "default",
+			},
+			Spec: topology.SchemaReplicationSpec{
+				UpstreamSecret: &corev1.LocalObjectReference{
+					Name: "endpoints-secret", // created in 'BeforeSuite'
 				},
-				Spec: topology.SchemaReplicationSpec{
-					UpstreamSecret: &corev1.LocalObjectReference{
-						Name: "endpoints-secret", // created in 'BeforeSuite'
-					},
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-			}
-		})
+			},
+		}
+	})
 
-		When("creation", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					replicationName = "test-replication-http-error"
-					fakeRabbitMQClient.PutGlobalParameterReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("some HTTP error"))
-				})
-
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &replication)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace},
-							&replication,
-						)
-
-						return replication.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some HTTP error"),
-					})))
-				})
+	When("creation", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				replicationName = "test-replication-http-error"
+				fakeRabbitMQClient.PutGlobalParameterReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("some HTTP error"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					replicationName = "test-replication-go-error"
-					fakeRabbitMQClient.PutGlobalParameterReturns(nil, errors.New("some go failure here"))
-				})
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &replication)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace},
+						&replication,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &replication)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace},
-							&replication,
-						)
-
-						return replication.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some go failure here"),
-					})))
-				})
-			})
-
-			Context("success", func() {
-				BeforeEach(func() {
-					replicationName = "test-replication-success"
-					fakeRabbitMQClient.PutGlobalParameterReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition 'Ready' to 'true'", func() {
-					Expect(client.Create(ctx, &replication)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace},
-							&replication,
-						)
-
-						return replication.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return replication.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some HTTP error"),
+				})))
 			})
 		})
 
-		When("deletion", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				replicationName = "test-replication-go-error"
+				fakeRabbitMQClient.PutGlobalParameterReturns(nil, errors.New("some go failure here"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &replication)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace},
+						&replication,
+					)
+
+					return replication.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some go failure here"),
+				})))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				replicationName = "test-replication-success"
 				fakeRabbitMQClient.PutGlobalParameterReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &replication)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&replication)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.schemareplications.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -146,81 +126,86 @@ var _ = Describe("schema-replication-controller", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					replicationName = "delete-replication-http-error"
-					fakeRabbitMQClient.DeleteGlobalParameterReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	When("deletion", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.PutGlobalParameterReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &replication)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace},
+					&replication,
+				)
 
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &replication)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &topology.SchemaReplication{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete global parameter 'schema_definition_sync_upstream'"))
-				})
+				return replication.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				replicationName = "delete-replication-http-error"
+				fakeRabbitMQClient.DeleteGlobalParameterReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					replicationName = "delete-replication-go-error"
-					fakeRabbitMQClient.DeleteGlobalParameterReturns(nil, errors.New("some error"))
-				})
-
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &replication)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &topology.SchemaReplication{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete global parameter 'schema_definition_sync_upstream'"))
-				})
-			})
-
-			Context("success", func() {
-				BeforeEach(func() {
-					replicationName = "delete-replication-success"
-					fakeRabbitMQClient.DeleteGlobalParameterReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("publishes a normal event", func() {
-					Expect(client.Delete(ctx, &replication)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &topology.SchemaReplication{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete global parameter 'schema_definition_sync_upstream'")),
-						ContainElement("Normal SuccessfulDelete successfully delete 'schema_definition_sync_upstream' global parameter"),
-					))
-				})
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &replication)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &topology.SchemaReplication{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete global parameter 'schema_definition_sync_upstream'"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				replicationName = "finalizer-test"
+				replicationName = "delete-replication-go-error"
+				fakeRabbitMQClient.DeleteGlobalParameterReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &replication)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.SchemaReplication
-					err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.schemareplications.rabbitmq.com"))
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &replication)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &topology.SchemaReplication{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete global parameter 'schema_definition_sync_upstream'"))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				replicationName = "delete-replication-success"
+				fakeRabbitMQClient.DeleteGlobalParameterReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("publishes a normal event", func() {
+				Expect(client.Delete(ctx, &replication)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: replication.Name, Namespace: replication.Namespace}, &topology.SchemaReplication{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete global parameter 'schema_definition_sync_upstream'")),
+					ContainElement("Normal SuccessfulDelete successfully delete 'schema_definition_sync_upstream' global parameter"),
+				))
 			})
 		})
 	})

--- a/controllers/shovel_controller_test.go
+++ b/controllers/shovel_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,113 +22,92 @@ var _ = Describe("shovel-controller", func() {
 	var shovel topology.Shovel
 	var shovelName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			shovel = topology.Shovel{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      shovelName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		shovel = topology.Shovel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shovelName,
+				Namespace: "default",
+			},
+			Spec: topology.ShovelSpec{
+				Name:      "my-shovel-configuration",
+				Vhost:     "/test",
+				UriSecret: &corev1.LocalObjectReference{Name: "shovel-uri-secret"},
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-				Spec: topology.ShovelSpec{
-					Name:      "my-shovel-configuration",
-					Vhost:     "/test",
-					UriSecret: &corev1.LocalObjectReference{Name: "shovel-uri-secret"},
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
-				},
-			}
-		})
+			},
+		}
+	})
 
-		When("creation", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					shovelName = "test-shovel-http-error"
-					fakeRabbitMQClient.DeclareShovelReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("some HTTP error"))
-				})
-
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &shovel)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace},
-							&shovel,
-						)
-
-						return shovel.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some HTTP error"),
-					})))
-				})
+	When("creation", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				shovelName = "test-shovel-http-error"
+				fakeRabbitMQClient.DeclareShovelReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("some HTTP error"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					shovelName = "test-shovel-go-error"
-					fakeRabbitMQClient.DeclareShovelReturns(nil, errors.New("a go failure"))
-				})
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &shovel)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace},
+						&shovel,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &shovel)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace},
-							&shovel,
-						)
-
-						return shovel.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a go failure"),
-					})))
-				})
-			})
-
-			Context("success", func() {
-				BeforeEach(func() {
-					shovelName = "test-shovel-success"
-					fakeRabbitMQClient.DeclareShovelReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition 'Ready' to 'true'", func() {
-					Expect(client.Create(ctx, &shovel)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace},
-							&shovel,
-						)
-
-						return shovel.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return shovel.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some HTTP error"),
+				})))
 			})
 		})
 
-		When("deletion", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				shovelName = "test-shovel-go-error"
+				fakeRabbitMQClient.DeclareShovelReturns(nil, errors.New("a go failure"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &shovel)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace},
+						&shovel,
+					)
+
+					return shovel.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a go failure"),
+				})))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				shovelName = "test-shovel-success"
 				fakeRabbitMQClient.DeclareShovelReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &shovel)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&shovel)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.shovels.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -142,81 +122,86 @@ var _ = Describe("shovel-controller", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					shovelName = "delete-shovel-http-error"
-					fakeRabbitMQClient.DeleteShovelReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	When("deletion", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.DeclareShovelReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &shovel)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace},
+					&shovel,
+				)
 
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &shovel)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &topology.Shovel{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete shovel parameter"))
-				})
+				return shovel.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				shovelName = "delete-shovel-http-error"
+				fakeRabbitMQClient.DeleteShovelReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					shovelName = "delete-shovel-go-error"
-					fakeRabbitMQClient.DeleteShovelReturns(nil, errors.New("some error"))
-				})
-
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &shovel)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &topology.Shovel{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete shovel parameter"))
-				})
-			})
-
-			Context("success", func() {
-				BeforeEach(func() {
-					shovelName = "delete-shovel-success"
-					fakeRabbitMQClient.DeleteShovelReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("publishes a normal event", func() {
-					Expect(client.Delete(ctx, &shovel)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &topology.Shovel{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete shovel parameter")),
-						ContainElement("Normal SuccessfulDelete successfully deleted shovel parameter"),
-					))
-				})
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &shovel)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &topology.Shovel{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete shovel parameter"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				shovelName = "finalizer-test"
+				shovelName = "delete-shovel-go-error"
+				fakeRabbitMQClient.DeleteShovelReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &shovel)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.Shovel
-					err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.shovels.rabbitmq.com"))
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &shovel)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &topology.Shovel{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete shovel parameter"))
+			})
+		})
+
+		Context("success", func() {
+			BeforeEach(func() {
+				shovelName = "delete-shovel-success"
+				fakeRabbitMQClient.DeleteShovelReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("publishes a normal event", func() {
+				Expect(client.Delete(ctx, &shovel)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: shovel.Name, Namespace: shovel.Namespace}, &topology.Shovel{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete shovel parameter")),
+					ContainElement("Normal SuccessfulDelete successfully deleted shovel parameter"),
+				))
 			})
 		})
 	})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -14,6 +14,7 @@ import (
 	"crypto/x509"
 	"go/build"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"testing"
 
 	"github.com/rabbitmq/messaging-topology-operator/rabbitmqclient"
@@ -187,6 +188,9 @@ var _ = BeforeSuite(func() {
 
 	client = mgr.GetClient()
 	Expect(client).ToNot(BeNil())
+
+	komega.SetClient(client)
+	komega.SetContext(ctx)
 
 	rmqCreds := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,142 +22,88 @@ var _ = Describe("UserController", func() {
 	var user topology.User
 	var userName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			user = topology.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      userName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		user = topology.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userName,
+				Namespace: "default",
+			},
+			Spec: topology.UserSpec{
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-				Spec: topology.UserSpec{
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
-				},
-			}
-		})
-		When("creating a user", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					userName = "test-user-http-error"
-					fakeRabbitMQClient.PutUserReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("some HTTP error"))
-				})
-
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &user)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
-							&user,
-						)
-
-						return user.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("some HTTP error"),
-					})))
-				})
+			},
+		}
+	})
+	When("creating a user", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				userName = "test-user-http-error"
+				fakeRabbitMQClient.PutUserReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("some HTTP error"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					userName = "test-user-go-error"
-					fakeRabbitMQClient.PutUserReturns(nil, errors.New("hit a exception"))
-				})
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &user)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
+						&user,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &user)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
-							&user,
-						)
-
-						return user.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("hit a exception"),
-					})))
-				})
-			})
-
-			When("the RabbitMQ Client successfully creates a user", func() {
-				BeforeEach(func() {
-					userName = "test-user-success"
-					fakeRabbitMQClient.PutUserReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition to indicate a success in reconciling", func() {
-					Expect(client.Create(ctx, &user)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
-							&user,
-						)
-
-						return user.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-					Expect(user.Status.Username).Should(Not(BeEmpty()))
-				})
-				It("sets an owner reference and does not block owner deletion", func() {
-					user.Name = "test-owner-reference"
-					Expect(client.Create(ctx, &user)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
-							&user,
-						)
-
-						return user.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})), "User should have been created and have a True Ready condition")
-
-					generatedSecret := &corev1.Secret{}
-					EventuallyWithOffset(1, func() error {
-						return client.Get(ctx,
-							types.NamespacedName{
-								Namespace: user.Namespace,
-								Name:      user.Name + "-user-credentials",
-							}, generatedSecret)
-					}, 10*time.Second).ShouldNot(HaveOccurred())
-
-					for _, ref := range generatedSecret.ObjectMeta.OwnerReferences {
-						Expect(ref).To(MatchFields(IgnoreExtras, Fields{
-							"BlockOwnerDeletion": PointTo(BeFalse()),
-						}))
-					}
-				})
+					return user.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("some HTTP error"),
+				})))
 			})
 		})
 
-		When("deleting a user", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				userName = "test-user-go-error"
+				fakeRabbitMQClient.PutUserReturns(nil, errors.New("hit a exception"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &user)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
+						&user,
+					)
+
+					return user.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("hit a exception"),
+				})))
+			})
+		})
+
+		When("the RabbitMQ Client successfully creates a user", func() {
+			BeforeEach(func() {
+				userName = "test-user-success"
 				fakeRabbitMQClient.PutUserReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &user)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&user)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.users.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -170,112 +117,151 @@ var _ = Describe("UserController", func() {
 					"Reason": Equal("SuccessfulCreateOrUpdate"),
 					"Status": Equal(corev1.ConditionTrue),
 				})))
+				Expect(user.Status.Username).Should(Not(BeEmpty()))
 			})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					userName = "delete-user-http-error"
-					fakeRabbitMQClient.DeleteUserReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+			It("sets an owner reference and does not block owner deletion", func() {
+				user.Name = "test-owner-reference"
+				Expect(client.Create(ctx, &user)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
+						&user,
+					)
 
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &user)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete user"))
-				})
-			})
+					return user.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(topology.ConditionType("Ready")),
+					"Reason": Equal("SuccessfulCreateOrUpdate"),
+					"Status": Equal(corev1.ConditionTrue),
+				})), "User should have been created and have a True Ready condition")
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					userName = "delete-user-go-error"
-					fakeRabbitMQClient.DeleteUserReturns(nil, errors.New("some error"))
-				})
-
-				It("raises an event to indicate a failure to delete", func() {
-					Expect(client.Delete(ctx, &user)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete user"))
-				})
-			})
-
-			When("the RabbitMQ Client successfully deletes a user without secret", func() {
-				BeforeEach(func() {
-					userName = "delete-user-success-without-secret-user-credentials"
-					fakeRabbitMQClient.DeleteUserReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("raises an event to indicate a successful deletion", func() {
-					Expect(client.Delete(ctx, &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      user.Name + "-user-credentials",
+				generatedSecret := &corev1.Secret{}
+				EventuallyWithOffset(1, func() error {
+					return client.Get(ctx,
+						types.NamespacedName{
 							Namespace: user.Namespace,
-						},
-					})).To(Succeed())
-					Expect(client.Delete(ctx, &user)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
+							Name:      user.Name + "-user-credentials",
+						}, generatedSecret)
+				}, 10*time.Second).ShouldNot(HaveOccurred())
 
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete user")),
-						ContainElement("Normal SuccessfulDelete successfully deleted user"),
-					))
-				})
+				for _, ref := range generatedSecret.ObjectMeta.OwnerReferences {
+					Expect(ref).To(MatchFields(IgnoreExtras, Fields{
+						"BlockOwnerDeletion": PointTo(BeFalse()),
+					}))
+				}
+			})
+		})
+	})
+
+	When("deleting a user", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.PutUserReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &user)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
+					&user,
+				)
+
+				return user.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				userName = "delete-user-http-error"
+				fakeRabbitMQClient.DeleteUserReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client successfully deletes a user", func() {
-				BeforeEach(func() {
-					userName = "delete-user-success"
-					fakeRabbitMQClient.DeleteUserReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("raises an event to indicate a successful deletion", func() {
-					Expect(client.Delete(ctx, &user)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete user")),
-						ContainElement("Normal SuccessfulDelete successfully deleted user"),
-					))
-				})
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &user)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete user"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				userName = "finalizer-test"
+				userName = "delete-user-go-error"
+				fakeRabbitMQClient.DeleteUserReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &user)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.User
-					err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.users.rabbitmq.com"))
+			It("raises an event to indicate a failure to delete", func() {
+				Expect(client.Delete(ctx, &user)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete user"))
+			})
+		})
+
+		When("the RabbitMQ Client successfully deletes a user without secret", func() {
+			BeforeEach(func() {
+				userName = "delete-user-success-without-secret-user-credentials"
+				fakeRabbitMQClient.DeleteUserReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("raises an event to indicate a successful deletion", func() {
+				Expect(client.Delete(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      user.Name + "-user-credentials",
+						Namespace: user.Namespace,
+					},
+				})).To(Succeed())
+				Expect(client.Delete(ctx, &user)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete user")),
+					ContainElement("Normal SuccessfulDelete successfully deleted user"),
+				))
+			})
+		})
+
+		When("the RabbitMQ Client successfully deletes a user", func() {
+			BeforeEach(func() {
+				userName = "delete-user-success"
+				fakeRabbitMQClient.DeleteUserReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("raises an event to indicate a successful deletion", func() {
+				Expect(client.Delete(ctx, &user)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete user")),
+					ContainElement("Normal SuccessfulDelete successfully deleted user"),
+				))
 			})
 		})
 	})

--- a/controllers/vhost_controller_test.go
+++ b/controllers/vhost_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,110 +22,89 @@ var _ = Describe("vhost-controller", func() {
 	var vhost topology.Vhost
 	var vhostName string
 
-	When("validating RabbitMQ Client failures", func() {
-		JustBeforeEach(func() {
-			vhost = topology.Vhost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vhostName,
-					Namespace: "default",
+	JustBeforeEach(func() {
+		vhost = topology.Vhost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vhostName,
+				Namespace: "default",
+			},
+			Spec: topology.VhostSpec{
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: "example-rabbit",
 				},
-				Spec: topology.VhostSpec{
-					RabbitmqClusterReference: topology.RabbitmqClusterReference{
-						Name: "example-rabbit",
-					},
-				},
-			}
-		})
+			},
+		}
+	})
 
-		Context("creation", func() {
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					vhostName = "test-http-error"
-					fakeRabbitMQClient.PutVhostReturns(&http.Response{
-						Status:     "418 I'm a teapot",
-						StatusCode: 418,
-					}, errors.New("a failure"))
-				})
-
-				It("sets the status condition", func() {
-					Expect(client.Create(ctx, &vhost)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace},
-							&vhost,
-						)
-
-						return vhost.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a failure"),
-					})))
-				})
+	Context("creation", func() {
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				vhostName = "test-http-error"
+				fakeRabbitMQClient.PutVhostReturns(&http.Response{
+					Status:     "418 I'm a teapot",
+					StatusCode: 418,
+				}, errors.New("a failure"))
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					vhostName = "test-go-error"
-					fakeRabbitMQClient.PutVhostReturns(nil, errors.New("a go failure"))
-				})
+			It("sets the status condition", func() {
+				Expect(client.Create(ctx, &vhost)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace},
+						&vhost,
+					)
 
-				It("sets the status condition to indicate a failure to reconcile", func() {
-					Expect(client.Create(ctx, &vhost)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace},
-							&vhost,
-						)
-
-						return vhost.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(topology.ConditionType("Ready")),
-						"Reason":  Equal("FailedCreateOrUpdate"),
-						"Status":  Equal(corev1.ConditionFalse),
-						"Message": ContainSubstring("a go failure"),
-					})))
-				})
-			})
-
-			When("success", func() {
-				BeforeEach(func() {
-					vhostName = "test-create-success"
-					fakeRabbitMQClient.PutVhostReturns(&http.Response{
-						Status:     "201 Created",
-						StatusCode: http.StatusCreated,
-					}, nil)
-				})
-
-				It("sets the status condition 'Ready' to 'true' ", func() {
-					Expect(client.Create(ctx, &vhost)).To(Succeed())
-					EventuallyWithOffset(1, func() []topology.Condition {
-						_ = client.Get(
-							ctx,
-							types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace},
-							&vhost,
-						)
-
-						return vhost.Status.Conditions
-					}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(topology.ConditionType("Ready")),
-						"Reason": Equal("SuccessfulCreateOrUpdate"),
-						"Status": Equal(corev1.ConditionTrue),
-					})))
-				})
+					return vhost.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a failure"),
+				})))
 			})
 		})
 
-		Context("deletion", func() {
-			JustBeforeEach(func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
+			BeforeEach(func() {
+				vhostName = "test-go-error"
+				fakeRabbitMQClient.PutVhostReturns(nil, errors.New("a go failure"))
+			})
+
+			It("sets the status condition to indicate a failure to reconcile", func() {
+				Expect(client.Create(ctx, &vhost)).To(Succeed())
+				EventuallyWithOffset(1, func() []topology.Condition {
+					_ = client.Get(
+						ctx,
+						types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace},
+						&vhost,
+					)
+
+					return vhost.Status.Conditions
+				}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(topology.ConditionType("Ready")),
+					"Reason":  Equal("FailedCreateOrUpdate"),
+					"Status":  Equal(corev1.ConditionFalse),
+					"Message": ContainSubstring("a go failure"),
+				})))
+			})
+		})
+
+		When("success", func() {
+			BeforeEach(func() {
+				vhostName = "test-create-success"
 				fakeRabbitMQClient.PutVhostReturns(&http.Response{
 					Status:     "201 Created",
 					StatusCode: http.StatusCreated,
 				}, nil)
+			})
+
+			It("works", func() {
 				Expect(client.Create(ctx, &vhost)).To(Succeed())
+				By("setting the correct finalizer")
+				Eventually(komega.Object(&vhost)).WithTimeout(2 * time.Second).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("deletion.finalizers.vhosts.rabbitmq.com")))
+
+				By("sets the status condition 'Ready' to 'true'")
 				EventuallyWithOffset(1, func() []topology.Condition {
 					_ = client.Get(
 						ctx,
@@ -139,81 +119,86 @@ var _ = Describe("vhost-controller", func() {
 					"Status": Equal(corev1.ConditionTrue),
 				})))
 			})
+		})
+	})
 
-			When("the RabbitMQ Client returns a HTTP error response", func() {
-				BeforeEach(func() {
-					vhostName = "delete-vhost-http-error"
-					fakeRabbitMQClient.DeleteVhostReturns(&http.Response{
-						Status:     "502 Bad Gateway",
-						StatusCode: http.StatusBadGateway,
-						Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
-					}, nil)
-				})
+	Context("deletion", func() {
+		JustBeforeEach(func() {
+			fakeRabbitMQClient.PutVhostReturns(&http.Response{
+				Status:     "201 Created",
+				StatusCode: http.StatusCreated,
+			}, nil)
+			Expect(client.Create(ctx, &vhost)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = client.Get(
+					ctx,
+					types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace},
+					&vhost,
+				)
 
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &vhost)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &topology.Vhost{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete vhost"))
-				})
+				return vhost.Status.Conditions
+			}, 10*time.Second, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+		})
+
+		When("the RabbitMQ Client returns a HTTP error response", func() {
+			BeforeEach(func() {
+				vhostName = "delete-vhost-http-error"
+				fakeRabbitMQClient.DeleteVhostReturns(&http.Response{
+					Status:     "502 Bad Gateway",
+					StatusCode: http.StatusBadGateway,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+				}, nil)
 			})
 
-			When("the RabbitMQ Client returns a Go error response", func() {
-				BeforeEach(func() {
-					vhostName = "delete-go-error"
-					fakeRabbitMQClient.DeleteVhostReturns(nil, errors.New("some error"))
-				})
-
-				It("publishes a 'warning' event", func() {
-					Expect(client.Delete(ctx, &vhost)).To(Succeed())
-					Consistently(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &topology.Vhost{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeFalse())
-					Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete vhost"))
-				})
-			})
-
-			When("the RabbitMQ Client successfully deletes a vhost", func() {
-				BeforeEach(func() {
-					vhostName = "delete-vhost-success"
-					fakeRabbitMQClient.DeleteVhostReturns(&http.Response{
-						Status:     "204 No Content",
-						StatusCode: http.StatusNoContent,
-					}, nil)
-				})
-
-				It("publishes a normal event", func() {
-					Expect(client.Delete(ctx, &vhost)).To(Succeed())
-					Eventually(func() bool {
-						err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &topology.Vhost{})
-						return apierrors.IsNotFound(err)
-					}, 5).Should(BeTrue())
-					Expect(observedEvents()).To(SatisfyAll(
-						Not(ContainElement("Warning FailedDelete failed to delete vhost")),
-						ContainElement("Normal SuccessfulDelete successfully deleted vhost"),
-					))
-				})
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &vhost)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &topology.Vhost{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete vhost"))
 			})
 		})
 
-		Context("finalizer", func() {
+		When("the RabbitMQ Client returns a Go error response", func() {
 			BeforeEach(func() {
-				vhostName = "finalizer-test"
+				vhostName = "delete-go-error"
+				fakeRabbitMQClient.DeleteVhostReturns(nil, errors.New("some error"))
 			})
 
-			It("sets the correct deletion finalizer to the object", func() {
-				Expect(client.Create(ctx, &vhost)).To(Succeed())
-				Eventually(func() []string {
-					var fetched topology.Vhost
-					err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &fetched)
-					if err != nil {
-						return []string{}
-					}
-					return fetched.ObjectMeta.Finalizers
-				}, 5).Should(ConsistOf("deletion.finalizers.vhosts.rabbitmq.com"))
+			It("publishes a 'warning' event", func() {
+				Expect(client.Delete(ctx, &vhost)).To(Succeed())
+				Consistently(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &topology.Vhost{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeFalse())
+				Expect(observedEvents()).To(ContainElement("Warning FailedDelete failed to delete vhost"))
+			})
+		})
+
+		When("the RabbitMQ Client successfully deletes a vhost", func() {
+			BeforeEach(func() {
+				vhostName = "delete-vhost-success"
+				fakeRabbitMQClient.DeleteVhostReturns(&http.Response{
+					Status:     "204 No Content",
+					StatusCode: http.StatusNoContent,
+				}, nil)
+			})
+
+			It("publishes a normal event", func() {
+				Expect(client.Delete(ctx, &vhost)).To(Succeed())
+				Eventually(func() bool {
+					err := client.Get(ctx, types.NamespacedName{Name: vhost.Name, Namespace: vhost.Namespace}, &topology.Vhost{})
+					return apierrors.IsNotFound(err)
+				}, 5).Should(BeTrue())
+				Expect(observedEvents()).To(SatisfyAll(
+					Not(ContainElement("Warning FailedDelete failed to delete vhost")),
+					ContainElement("Normal SuccessfulDelete successfully deleted vhost"),
+				))
 			})
 		})
 	})


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Some small tests updates and regenerate CRDs after k8s api and controller-gen was bumped.

komega is a test client from [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/envtest/komega/komega.go). Can be used in more places in integration tests but just the finalizer tests for now.

## Additional Context
