### PR TITLE
Exclude dependabot from autogenned release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+    authors:
+      - dependabot


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Porting https://github.com/rabbitmq/cluster-operator/pull/1116 to the topology operator.

## Additional Context
