### PR TITLE
Bump golang to 1.19

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.17.0' # Require Go 1.16 and above, but lower than Go 2.0.0
+        go-version: '^1.19.0' # Require Go 1.16 and above, but lower than Go 2.0.0
     - name: System tests
       env:
         K8S_VERSION: ${{ matrix.k8s }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rabbitmq/messaging-topology-operator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/cloudflare/cfssl v1.6.2


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Bump golang to 1.19

## Additional Context
