### PR TITLE
bumping go version to 1.19.2 in pr workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: '^1.19.1' # Require Go 1.19 and above, but lower than Go 2.0.0
+  GO_VERSION: '^1.19.2' # Require Go 1.19 and above, but lower than Go 2.0.0
 
 jobs:
 


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

## Additional Context
