### PR TITLE
Use github action v3 instead of v2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,11 +15,11 @@ jobs:
     container: us.gcr.io/cf-rabbitmq-for-k8s-bunny/rabbitmq-for-kubernetes-ci
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Unit tests
       run: make unit-tests
     - name: Integration tests
@@ -33,8 +33,8 @@ jobs:
         k8s: [v1.22.9, v1.24.1]
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+      uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: System tests


### PR DESCRIPTION
Related PR in cluster operator https://github.com/rabbitmq/cluster-operator/pull/1177

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

This will get rid of "Node.js 12 actions are deprecated" warnings in our actions.

## Additional Context
