### PR TITLE
Use latest go patch in github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: '^1.19.2' # Require Go 1.19 and above, but lower than Go 2.0.0
+  GO_VERSION: '^1.19' # Require Go 1.19 and above, but lower than Go 2.0.0
 
 jobs:
 
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
     - name: Unit tests
@@ -37,6 +38,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        check-latest: true
     - name: System tests
       env:
         K8S_VERSION: ${{ matrix.k8s }}


### PR DESCRIPTION
This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Use latest go patch in github action. This will make `govulncheck` less likely to fail. 

## Additional Context
