### PR TITLE
Stop logging renewal info to avoid leaking creds.

### DIFF
--- a/rabbitmqclient/vault_reader.go
+++ b/rabbitmqclient/vault_reader.go
@@ -273,8 +273,8 @@ func manageTokenLifecycle(client *vault.Client, token *vault.Secret) error {
 			return nil
 
 		// Successfully completed renewal
-		case renewal := <-watcher.RenewCh():
-			logger.Info("Successfully renewed Vault token", "renewal info", renewal)
+		case <-watcher.RenewCh():
+			logger.Info("Successfully renewed Vault token")
 		}
 	}
 }


### PR DESCRIPTION
This closes #545 

## Summary Of Changes

Avoid logging vault renewal info. This info can contain credentials. 

## Additional Context

A related issue has been opened in the Vault examples repo https://github.com/hashicorp/vault-examples/issues/23
