### PR TITLE
Add single-arch builds for commercial edition.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -80,6 +80,24 @@ jobs:
         platforms: linux/amd64, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+    - name: OCI Metadata for single-arch image
+      id: single-arch-meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          rabbitmqoperator/messaging-topology-operator
+        flavor: |
+          latest=false
+        tags: |
+          type=semver,pattern={{version}},type=sha,suffix=-amd64,latest=false
+    - name: Build and push single-arch image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/amd64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.single-arch-meta.outputs.tags }}
+        labels: ${{ steps.single-arch-meta.outputs.labels }}
     - name: Build manifest
       env:
         RELEASE_VERSION: ${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Multi-arch support was added with the github actions migration (closing #521 ), this is to additionally build a single-arch amd64 image for use-cases that do not support multi-arch images.
