### PR TITLE
udpating error message returned from getUserCredentials to avoid logs looping …

### DIFF
--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -193,7 +193,7 @@ func (r *UserReconciler) DeclareFunc(ctx context.Context, client rabbitmqclient.
 
 	credentials, err := r.getUserCredentials(ctx, user)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve user credentials secret from status; user.status: %v", user.Status)
+		return fmt.Errorf("failed to retrieve user credentials secret from status; error: %w", err)
 	}
 	logger.Info("Retrieved credentials for user", "user", user.Name, "credentials", credentials.Name)
 


### PR DESCRIPTION
…forever

This closes #

https://github.com/rabbitmq/messaging-topology-operator/issues/551

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

It seems like that when we delete a credential user secret the messaging operator prints continuously logs like:

ZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} EZI43wvWvLfxxFsWYdeykLxeKy4mWMX5}}] &LocalObjectReference{Name:myuser-2-user-credentials,} 

and 

2023-03-06T14:21:00Z	ERROR	Reconciler error	{"controller": "user", "controllerGroup": "rabbitmq.com", "controllerKind": "User", "User": {"name":"myuser-2","namespace":"rabbitmq-system"}, "namespace": "rabbitmq-system", "name": "myuser-2", "reconcileID": "cd7a69ea-5e53-4e2f-9523-746062bd13bf", "error": "failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from status; user.status: {1 [{Ready False 2023-03-06 14:20:41 +0000 UTC FailedCreateOrUpdate failed to retrieve user credentials secret from statu

This modification seems preventing this to happen. The error will be printed just at every reconciliation loop.

## Additional Context
