### PR TITLE
Generate arm64 image

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -79,8 +79,8 @@ jobs:
         platforms: linux/amd64, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-    - name: OCI Metadata for single-arch image
-      id: single-arch-meta
+    - name: OCI Metadata for amd64 image
+      id: single-arch-meta-amd64
       uses: docker/metadata-action@v4
       with:
         images: |
@@ -89,14 +89,32 @@ jobs:
           latest=false
         tags: |
           type=semver,pattern={{version}},type=sha,suffix=-amd64,latest=false
-    - name: Build and push single-arch image
+    - name: Build and push single-arch amd64 image
       uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.single-arch-meta.outputs.tags }}
-        labels: ${{ steps.single-arch-meta.outputs.labels }}
+        tags: ${{ steps.single-arch-meta-amd64.outputs.tags }}
+        labels: ${{ steps.single-arch-meta-amd64.outputs.labels }}
+    - name: OCI Metadata for arm64 image
+      id: single-arch-meta-arm64
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          rabbitmqoperator/messaging-topology-operator
+        flavor: |
+          latest=false
+        tags: |
+          type=semver,pattern={{version}},type=sha,suffix=-arm64,latest=false
+    - name: Build and push single-arch arm64 image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.single-arch-meta-arm64.outputs.tags }}
+        labels: ${{ steps.single-arch-meta-arm64.outputs.labels }}
     - name: Build manifest
       env:
         RELEASE_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -79,7 +79,7 @@ jobs:
         platforms: linux/amd64, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-    - name: OCI Metadata for amd64 image
+    - name: OCI Metadata for single-arch amd64 image
       id: single-arch-meta-amd64
       uses: docker/metadata-action@v4
       with:
@@ -97,7 +97,7 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.single-arch-meta-amd64.outputs.tags }}
         labels: ${{ steps.single-arch-meta-amd64.outputs.labels }}
-    - name: OCI Metadata for arm64 image
+    - name: OCI Metadata for single-arch arm64 image
       id: single-arch-meta-arm64
       uses: docker/metadata-action@v4
       with:


### PR DESCRIPTION
This contributes to https://github.com/rabbitmq/service-operator-experience/issues/164

Workflow is updated to also build and publish single-arch arm64 image.
Currently the workflow builds and publishes multi-arch (amd64/arm64) and single-arch (amd64) images.