### PR TITLE
fix bug when deleting a binding in bindBindingInfo

### DIFF
--- a/controllers/binding_controller.go
+++ b/controllers/binding_controller.go
@@ -96,9 +96,9 @@ func (r *BindingReconciler) findBindingInfo(logger logr.Logger, binding *topolog
 		return nil, err
 	}
 	var info *rabbithole.BindingInfo
-	for _, b := range bindingInfos {
+	for i, b := range bindingInfos {
 		if binding.Spec.RoutingKey == b.RoutingKey && reflect.DeepEqual(b.Arguments, arguments) {
-			info = &b
+			info = &bindingInfos[i]
 		}
 	}
 	return info, nil


### PR DESCRIPTION
This closes #

This fix is solving a bug in the binding controller when deleting a binding. Sometimes a wrong binding get deleted.
Scenario can be in ticket VESC-1064

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

## Additional Context
