### PR TITLE
Let Dockerfile to support multiarch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,7 +17,13 @@ COPY internal/ internal/
 COPY rabbitmqclient/ rabbitmqclient/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -tags timetzdata -o manager main.go
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS $TARGETOS
+ENV GOARCH $TARGETARCH
+
+# Build
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -tags timetzdata -o manager main.go
 
 # ---------------------------------------
 FROM alpine:latest as etc-builder

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ deploy-dev: check-env-docker-credentials cmctl docker-build-dev manifests deploy
 
 # Load operator image and deploy operator into current KinD cluster
 deploy-kind: manifests cmctl deploy-rbac
-	$(BUILD_KIT) build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
+	$(BUILD_KIT) buildx build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
 	kind load docker-image $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)
 	$(CMCTL) check api --wait=2m
 	kustomize build config/default/overlays/kind | sed 's@((operator_docker_image))@"$(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)"@' | kubectl apply -f -
@@ -160,7 +160,7 @@ ifndef DOCKER_REGISTRY_SECRET
 endif
 
 docker-build-dev: check-env-docker-repo  git-commit-sha
-	$(BUILD_KIT) build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
+	$(BUILD_KIT) buildx build --build-arg=GIT_COMMIT=$(GIT_COMMIT) -t $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT) .
 	$(BUILD_KIT) push $(DOCKER_REGISTRY_SERVER)/$(OPERATOR_IMAGE):$(GIT_COMMIT)
 
 docker-registry-secret: check-env-docker-credentials operator-namespace


### PR DESCRIPTION
This closes #570

There are currently some issues on the arm64 deployment https://github.com/rabbitmq/messaging-topology-operator/issues/570

The dockerfile sees to build just on amd64

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

## Additional Context
