### PR TITLE
Bump k8s version in github actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.22.9, v1.24.1]
+        k8s: [v1.22.17, v1.26.3]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Test on k8s `1.26` instead of `1.24` in PR github actions.

## Additional Context
