### PR TITLE
621 allow for plain http connections 

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -32,4 +32,5 @@ const (
 	OperatorNamespaceEnvVar        = "OPERATOR_NAMESPACE"
 	EnableWebhooksEnvVar           = "ENABLE_WEBHOOKS"
 	ControllerSyncPeriodEnvVar     = "SYNC_PERIOD"
+	ConnectUsingPlainHTTPEnvVar    = "CONNECT_USING_PLAIN_HTTP"
 )

--- a/controllers/topology_controller.go
+++ b/controllers/topology_controller.go
@@ -33,6 +33,7 @@ type TopologyReconciler struct {
 	Recorder                record.EventRecorder
 	RabbitmqClientFactory   rabbitmqclient.Factory
 	KubernetesClusterDomain string
+	ConnectUsingPlainHTTP   bool
 }
 
 func (r *TopologyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -48,7 +49,7 @@ func (r *TopologyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	credsProvider, tlsEnabled, err := rabbitmqclient.ParseReference(ctx, r.Client, obj.RabbitReference(), obj.GetNamespace(), r.KubernetesClusterDomain)
+	credsProvider, tlsEnabled, err := rabbitmqclient.ParseReference(ctx, r.Client, obj.RabbitReference(), obj.GetNamespace(), r.KubernetesClusterDomain, r.ConnectUsingPlainHTTP)
 	if err != nil {
 		return r.handleRMQReferenceParseError(ctx, obj, err)
 	}

--- a/rabbitmqclient/cluster_reference.go
+++ b/rabbitmqclient/cluster_reference.go
@@ -32,6 +32,8 @@ var (
 	NoServiceReferenceSetError = errors.New("RabbitmqCluster has no ServiceReference set in status.defaultUser")
 )
 
+var usePlainHTTP bool = false
+
 func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqClusterReference, requestNamespace string, clusterDomain string) (map[string]string, bool, error) {
 	if rmq.ConnectionSecret != nil {
 		secret := &corev1.Secret{}
@@ -99,8 +101,8 @@ func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqC
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to parse additionconfig setting from the rabbitmqcluster resource: %w", err)
 	}
-
-	endpoint, err := managementURI(svc, cluster.TLSEnabled(), clusterDomain, additionalConfig["management.path_prefix"])
+	useTLSForConnection := cluster.TLSEnabled() && !usePlainHTTP
+	endpoint, err := managementURI(svc, useTLSForConnection, clusterDomain, additionalConfig["management.path_prefix"])
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get endpoint from specified rabbitmqcluster: %w", err)
 	}
@@ -109,7 +111,7 @@ func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqC
 		"username": user,
 		"password": pass,
 		"uri":      endpoint,
-	}, cluster.TLSEnabled(), nil
+	}, useTLSForConnection, nil
 }
 
 func AllowedNamespace(rmq topology.RabbitmqClusterReference, requestNamespace string, cluster *rabbitmqv1beta1.RabbitmqCluster) bool {
@@ -178,25 +180,28 @@ func readUsernamePassword(secret *corev1.Secret) (string, string, error) {
 	return string(secret.Data["username"]), string(secret.Data["password"]), nil
 }
 
-func managementURI(svc *corev1.Service, tlsEnabled bool, clusterDomain string, pathPrefix string) (string, error) {
+func managementURI(svc *corev1.Service, useTLSForConnection bool, clusterDomain string, pathPrefix string) (string, error) {
 	var managementUiPort int
+	var portName string
+
+	if useTLSForConnection {
+		portName = "management-tls"
+	} else {
+		portName = "management"
+	}
 	for _, port := range svc.Spec.Ports {
-		if port.Name == "management-tls" {
+		if port.Name == portName {
 			managementUiPort = int(port.Port)
 			break
-		}
-		if port.Name == "management" {
-			managementUiPort = int(port.Port)
-			// Do not break here because we may still find 'management-tls' port
 		}
 	}
 
 	if managementUiPort == 0 {
-		return "", fmt.Errorf("failed to find 'management' or 'management-tls' from service %s", svc.Name)
+		return "", fmt.Errorf("failed to find %s from service %s", portName, svc.Name)
 	}
 
 	scheme := "http"
-	if tlsEnabled {
+	if useTLSForConnection {
 		scheme = "https"
 	}
 	url := url.URL{

--- a/rabbitmqclient/cluster_reference.go
+++ b/rabbitmqclient/cluster_reference.go
@@ -32,9 +32,7 @@ var (
 	NoServiceReferenceSetError = errors.New("RabbitmqCluster has no ServiceReference set in status.defaultUser")
 )
 
-var usePlainHTTP bool = false
-
-func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqClusterReference, requestNamespace string, clusterDomain string) (map[string]string, bool, error) {
+func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqClusterReference, requestNamespace string, clusterDomain string, connectUsingHTTP bool) (map[string]string, bool, error) {
 	if rmq.ConnectionSecret != nil {
 		secret := &corev1.Secret{}
 		if err := c.Get(ctx, types.NamespacedName{Namespace: requestNamespace, Name: rmq.ConnectionSecret.Name}, secret); err != nil {
@@ -101,7 +99,7 @@ func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqC
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to parse additionconfig setting from the rabbitmqcluster resource: %w", err)
 	}
-	useTLSForConnection := cluster.TLSEnabled() && !usePlainHTTP
+	useTLSForConnection := cluster.TLSEnabled() && !connectUsingHTTP
 	endpoint, err := managementURI(svc, useTLSForConnection, clusterDomain, additionalConfig["management.path_prefix"])
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get endpoint from specified rabbitmqcluster: %w", err)

--- a/rabbitmqclient/cluster_reference_test.go
+++ b/rabbitmqclient/cluster_reference_test.go
@@ -328,8 +328,8 @@ var _ = Describe("ParseReference", func() {
 					ClusterIP: "1.2.3.4",
 					Ports: []corev1.ServicePort{
 						{
-							Name: "management-tls",
-							Port: int32(15671),
+							Name: "management",
+							Port: int32(15672),
 						},
 					},
 				},
@@ -349,7 +349,7 @@ var _ = Describe("ParseReference", func() {
 			uriBytes, _ := creds["uri"]
 			Expect(usernameBytes).To(Equal(existingRabbitMQUsername))
 			Expect(passwordBytes).To(Equal(existingRabbitMQPassword))
-			Expect(uriBytes).To(Equal("http://rmq.rabbitmq-system.svc:15671/my/prefix"))
+			Expect(uriBytes).To(Equal("http://rmq.rabbitmq-system.svc:15672/my/prefix"))
 		})
 	})
 


### PR DESCRIPTION
This closes #621 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
With the env variable `CONNECT_USING_PLAIN_HTTP` it is possible to configure the topology operator to communicate with the RabbitMQ Cluster using plain http, even if the cluster has TLS enabled. This is will remove the limitation 

> Messaging Topology Operator will not attempt to connect to the RabbitmqCluster over HTTP if HTTPS is available (even if the certificate is not trusted)

documented in https://www.rabbitmq.com/kubernetes/operator/tls-topology-operator.html, and allow users to decide whether HTTP or HTTPS should be used.

Default behavior remains unchanged in that _not_ setting the flag will cause the operator to keep trying to establish a HTTPS connection.
