### PR TITLE
Add default queue type config to vhost crd

### DIFF
--- a/api/v1beta1/vhost_types.go
+++ b/api/v1beta1/vhost_types.go
@@ -21,6 +21,10 @@ type VhostSpec struct {
 	Name    string   `json:"name"`
 	Tracing bool     `json:"tracing,omitempty"`
 	Tags    []string `json:"tags,omitempty"`
+	// Default queue type for this vhost; can be set to quorum, classic or stream.
+	// Supported in RabbitMQ 3.11.12 or above.
+	// +kubebuilder:validation:Enum=quorum;classic;stream
+	DefaultQueueType string `json:"defaultQueueType,omitempty"`
 	// Reference to the RabbitmqCluster that the vhost will be created in.
 	// Required property.
 	// +kubebuilder:validation:Required

--- a/api/v1beta1/vhost_webhook_test.go
+++ b/api/v1beta1/vhost_webhook_test.go
@@ -15,8 +15,9 @@ var _ = Describe("vhost webhook", func() {
 			Name: "test-vhost",
 		},
 		Spec: VhostSpec{
-			Name:    "test",
-			Tracing: false,
+			Name:             "test",
+			Tracing:          false,
+			DefaultQueueType: "classic",
 			RabbitmqClusterReference: RabbitmqClusterReference{
 				Name: "a-cluster",
 			},
@@ -82,6 +83,12 @@ var _ = Describe("vhost webhook", func() {
 		It("allows updates on vhost.spec.tags", func() {
 			newVhost := vhost.DeepCopy()
 			newVhost.Spec.Tags = []string{"new-tag"}
+			Expect(newVhost.ValidateUpdate(&vhost)).To(Succeed())
+		})
+
+		It("allows updates on vhost.spec.defaultQueueType", func() {
+			newVhost := vhost.DeepCopy()
+			newVhost.Spec.DefaultQueueType = "quorum"
 			Expect(newVhost.ValidateUpdate(&vhost)).To(Succeed())
 		})
 	})

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -37,6 +37,14 @@ spec:
           spec:
             description: VhostSpec defines the desired state of Vhost
             properties:
+              defaultQueueType:
+                description: Default queue type for this vhost; can be set to quorum,
+                  classic or stream. Supported in RabbitMQ 3.11.12 or above.
+                enum:
+                - quorum
+                - classic
+                - stream
+                type: string
               name:
                 description: Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
                 type: string

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -1226,6 +1226,7 @@ VhostSpec defines the desired state of Vhost
 | *`name`* __string__ | Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
 | *`tracing`* __boolean__ | 
 | *`tags`* __string array__ | 
+| *`defaultQueueType`* __string__ | Default queue type for this vhost; can be set to quorum, classic or stream. Supported in RabbitMQ 3.11.12 or above.
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the vhost will be created in. Required property.
 |===
 

--- a/docs/examples/vhosts/README.md
+++ b/docs/examples/vhosts/README.md
@@ -1,0 +1,4 @@
+# Vhost examples
+
+This section contains 1 example for creating a RabbitMQ vhost.
+Note that setting default queue type `spec.defaultQueueType` is only supported by RabbitMQ server version `3.11.12` or above.

--- a/docs/examples/vhosts/vhost.yaml
+++ b/docs/examples/vhosts/vhost.yaml
@@ -3,7 +3,8 @@ kind: Vhost
 metadata:
   name: test-vhost
 spec:
-  name: test-vhost # vhost name
+  name: test-vhost # vhost name; required and cannot be updated
+  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
   rabbitmqClusterReference:
     name: test # rabbitmqCluster must exist in the same namespace as this resource
 # status:

--- a/internal/vhost_settings.go
+++ b/internal/vhost_settings.go
@@ -16,7 +16,8 @@ import (
 
 func GenerateVhostSettings(v *topology.Vhost) *rabbithole.VhostSettings {
 	return &rabbithole.VhostSettings{
-		Tracing: v.Spec.Tracing,
-		Tags:    v.Spec.Tags,
+		Tracing:          v.Spec.Tracing,
+		Tags:             v.Spec.Tags,
+		DefaultQueueType: v.Spec.DefaultQueueType,
 	}
 }

--- a/internal/vhost_settings_test.go
+++ b/internal/vhost_settings_test.go
@@ -32,4 +32,10 @@ var _ = Describe("GenerateVhostSettings", func() {
 		settings := internal.GenerateVhostSettings(v)
 		Expect(settings.Tags).To(ConsistOf("tag1", "tag2", "multi_dc_replication"))
 	})
+
+	It("sets default queue type according to vhost.spec.defaultQueueType", func() {
+		v.Spec.DefaultQueueType = "stream"
+		settings := internal.GenerateVhostSettings(v)
+		Expect(settings.DefaultQueueType).To(Equal("stream"))
+	})
 })

--- a/system_tests/utils.go
+++ b/system_tests/utils.go
@@ -184,7 +184,8 @@ func basicTestRabbitmqCluster(name, namespace string) *rabbitmqv1beta1.RabbitmqC
 			Namespace: namespace,
 		},
 		Spec: rabbitmqv1beta1.RabbitmqClusterSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: pointer.Int32(1),
+			Image:    "rabbitmq:3-management",
 			Resources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("100Mi"),


### PR DESCRIPTION
This closes #608

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Default queue type for a vhost can be set to quorum, classic or stream. This configuration requires RabbitMQ `3.11.12`.

Field `spec.defaultQueueType`  is mutable but currently updating it takes no effect. Default queue type can be updated with `rabbitmqctl` but not via http at the moment. I've added it in PR: https://github.com/rabbitmq/rabbitmq-server/pull/8342. After this PR to rabbitmq-server is merged and released, default queue type can be updated with topology operator successfully.

Update on May 30th, PR to rabbitmq-server is merged and will be related for `3.11.17`.

## Additional Context
