### PR TITLE
feat: Allow policy to apply to specific queue types (classic/quorum) & streams

### DIFF
--- a/api/v1beta1/policy_types.go
+++ b/api/v1beta1/policy_types.go
@@ -19,9 +19,9 @@ type PolicySpec struct {
 	// Required property.
 	// +kubebuilder:validation:Required
 	Pattern string `json:"pattern"`
-	// What this policy applies to: 'queues', 'exchanges', or 'all'.
+	// What this policy applies to: 'queues', 'classic_queues', 'quorum_queues', 'exchanges', or 'all'.
 	// Default to 'all'.
-	// +kubebuilder:validation:Enum=queues;exchanges;all
+	// +kubebuilder:validation:Enum=queues;classic_queues;quorum_queues;exchanges;all
 	// +kubebuilder:default:=all
 	ApplyTo string `json:"applyTo,omitempty"`
 	// Default to '0'.

--- a/api/v1beta1/policy_types.go
+++ b/api/v1beta1/policy_types.go
@@ -19,9 +19,9 @@ type PolicySpec struct {
 	// Required property.
 	// +kubebuilder:validation:Required
 	Pattern string `json:"pattern"`
-	// What this policy applies to: 'queues', 'classic_queues', 'quorum_queues', 'exchanges', or 'all'.
+	// What this policy applies to: 'queues', 'classic_queues', 'quorum_queues', 'streams', 'exchanges', or 'all'.
 	// Default to 'all'.
-	// +kubebuilder:validation:Enum=queues;classic_queues;quorum_queues;exchanges;all
+	// +kubebuilder:validation:Enum=queues;classic_queues;quorum_queues;streams;exchanges;all
 	// +kubebuilder:default:=all
 	ApplyTo string `json:"applyTo,omitempty"`
 	// Default to '0'.

--- a/api/v1beta1/policy_types_test.go
+++ b/api/v1beta1/policy_types_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Policy", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, &policy)).To(HaveOccurred())
-			Expect(k8sClient.Create(ctx, &policy)).To(MatchError(`Policy.rabbitmq.com "invalid" is invalid: spec.applyTo: Unsupported value: "yo-yo": supported values: "queues", "exchanges", "all"`))
+			Expect(k8sClient.Create(ctx, &policy)).To(MatchError(`Policy.rabbitmq.com "invalid" is invalid: spec.applyTo: Unsupported value: "yo-yo": supported values: "queues", "classic_queues", "quorum_queues", "exchanges", "all"`))
 		})
 	})
 

--- a/api/v1beta1/policy_types_test.go
+++ b/api/v1beta1/policy_types_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Policy", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, &policy)).To(HaveOccurred())
-			Expect(k8sClient.Create(ctx, &policy)).To(MatchError(`Policy.rabbitmq.com "invalid" is invalid: spec.applyTo: Unsupported value: "yo-yo": supported values: "queues", "classic_queues", "quorum_queues", "exchanges", "all"`))
+			Expect(k8sClient.Create(ctx, &policy)).To(MatchError(`Policy.rabbitmq.com "invalid" is invalid: spec.applyTo: Unsupported value: "yo-yo": supported values: "queues", "classic_queues", "quorum_queues", "streams", "exchanges", "all"`))
 		})
 	})
 

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -40,11 +40,13 @@ spec:
               applyTo:
                 default: all
                 description: 'What this policy applies to: ''queues'', ''classic_queues'',
-                  ''quorum_queues'', ''exchanges'', or ''all''. Default to ''all''.'
+                  ''quorum_queues'', ''streams'', ''exchanges'', or ''all''. Default
+                  to ''all''.'
                 enum:
                 - queues
                 - classic_queues
                 - quorum_queues
+                - streams
                 - exchanges
                 - all
                 type: string

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -39,10 +39,12 @@ spec:
             properties:
               applyTo:
                 default: all
-                description: 'What this policy applies to: ''queues'', ''exchanges'',
-                  or ''all''. Default to ''all''.'
+                description: 'What this policy applies to: ''queues'', ''classic_queues'',
+                  ''quorum_queues'', ''exchanges'', or ''all''. Default to ''all''.'
                 enum:
                 - queues
+                - classic_queues
+                - quorum_queues
                 - exchanges
                 - all
                 type: string


### PR DESCRIPTION
This closes #667.

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

This PR adds `classic_queues`, `quorum_queues`, `streams` to the list of supported values for the `ApplyTo` field of `Policy`.

## Additional Context

As far as I could see, no other changes are required for this functionality. This is just going through a kubernetes-side validation, and the `michaelklishin/rabbit-hole` client simply accepts any string for the `ApplyTo` field. Please correct me if I'm wrong, I'm not familiar with the entire codebase.