### PR TITLE
Fix issue with RabbitmqClusterReference Namespace Namespace and ConnectionSecret

### DIFF
--- a/rabbitmqclient/cluster_reference.go
+++ b/rabbitmqclient/cluster_reference.go
@@ -35,19 +35,19 @@ var (
 )
 
 func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqClusterReference, requestNamespace string, clusterDomain string, connectUsingHTTP bool) (map[string]string, bool, error) {
-	if rmq.ConnectionSecret != nil {
-		secret := &corev1.Secret{}
-		if err := c.Get(ctx, types.NamespacedName{Namespace: requestNamespace, Name: rmq.ConnectionSecret.Name}, secret); err != nil {
-			return nil, false, err
-		}
-		return readCredentialsFromKubernetesSecret(secret)
-	}
-
 	var namespace string
 	if rmq.Namespace == "" {
 		namespace = requestNamespace
 	} else {
 		namespace = rmq.Namespace
+	}
+
+	if rmq.ConnectionSecret != nil {
+		secret := &corev1.Secret{}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: rmq.ConnectionSecret.Name}, secret); err != nil {
+			return nil, false, err
+		}
+		return readCredentialsFromKubernetesSecret(secret)
 	}
 
 	cluster := &rabbitmqv1beta1.RabbitmqCluster{}

--- a/rabbitmqclient/cluster_reference_test.go
+++ b/rabbitmqclient/cluster_reference_test.go
@@ -485,6 +485,9 @@ var _ = Describe("ParseReference", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "rmq-connection-info",
 						Namespace: namespace,
+						Annotations: map[string]string{
+							"rabbitmq.com/topology-allowed-namespaces": "*",
+						},
 					},
 					Data: map[string][]byte{
 						"uri":      []byte("10.0.0.0:15672"),

--- a/rabbitmqclient/cluster_reference_test.go
+++ b/rabbitmqclient/cluster_reference_test.go
@@ -29,6 +29,7 @@ var _ = Describe("ParseReference", func() {
 		existingService          *corev1.Service
 		ctx                      = context.Background()
 		namespace                = "rabbitmq-system"
+		namespaceClient          = "client"
 		uriAnnotationKey         = "rabbitmq.com/operator-connection-uri"
 	)
 
@@ -464,6 +465,45 @@ var _ = Describe("ParseReference", func() {
 						},
 					},
 					namespace,
+					"",
+					false)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(tlsEnabled).To(BeFalse())
+				returnedUser, _ := creds["username"]
+				returnedPass, _ := creds["password"]
+				returnedURI, _ := creds["uri"]
+				Expect(returnedUser).To(Equal("test-user"))
+				Expect(returnedPass).To(Equal("test-password"))
+				Expect(returnedURI).To(Equal("http://10.0.0.0:15672"))
+			})
+		})
+
+		When("when object is placed in another namespace", func() {
+			BeforeEach(func() {
+				noSchemeSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rmq-connection-info",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"uri":      []byte("10.0.0.0:15672"),
+						"username": []byte("test-user"),
+						"password": []byte("test-password"),
+					},
+				}
+				objs = []runtime.Object{noSchemeSecret}
+			})
+
+			It("returns the expected connection information", func() {
+				creds, tlsEnabled, err := rabbitmqclient.ParseReference(ctx, fakeClient,
+					topology.RabbitmqClusterReference{
+						Namespace: namespace,
+						ConnectionSecret: &corev1.LocalObjectReference{
+							Name: "rmq-connection-info",
+						},
+					},
+					namespaceClient,
 					"",
 					false)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This closes #501

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
Fix an issue where Namespace was ignored when using ConnectionSecret.

## Additional Context
This doesn't look like a feature - it's more like a bug. Why support RabbitmqCluster via namespace but forbid secrets?