### PR TITLE
removing embedded namespace in tls system test

### DIFF
--- a/system_tests/tls_system_test.go
+++ b/system_tests/tls_system_test.go
@@ -30,7 +30,7 @@ var _ = Describe("RabbitMQ Cluster with TLS enabled", func() {
 
 	BeforeEach(func() {
 		tlsSecretName = fmt.Sprintf("rmq-test-cert-%v", uuid.New())
-		_, _, _ = createTLSSecret(tlsSecretName, namespace, "tls-cluster.rabbitmq-system.svc")
+		_, _, _ = createTLSSecret(tlsSecretName, namespace, "tls-cluster." + namespace + ".svc")
 
 		patchBytes, _ := fixtures.ReadFile("fixtures/patch-test-ca.yaml")
 		_, err := kubectl(
@@ -60,7 +60,7 @@ var _ = Describe("RabbitMQ Cluster with TLS enabled", func() {
 			StringData: map[string]string{
 				"username": user,
 				"password": pass,
-				"uri":      "https://tls-cluster.rabbitmq-system.svc:15671",
+				"uri":      "https://tls-cluster." + namespace + ".svc:15671",
 			},
 		}
 		Expect(k8sClient.Create(ctx, connectionSecret, &client.CreateOptions{})).To(Succeed())


### PR DESCRIPTION
Similarly to https://github.com/rabbitmq/cluster-operator/pull/1565

There are a few time when we embed the "rabbitmq-system" namespace not allowing the test to run on a different namespace.
