### PR TITLE
CI : Generate a trigger file for 'RabbitMQ for Kubernetes' dev CI pipeline

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -2,7 +2,7 @@ name: Build, Test, Publish Image & Manifest
 
 on:
   push:
-    branches: [ "trigger-carvel-bundle-dev-pipeline"]
+    branches: [ "main"]
     paths-ignore:
     - 'docs/**'
     - '*.md'

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -129,6 +129,7 @@ jobs:
         rabbitmqoperator/messaging-topology-operator-dev=rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
         popd
         make generate-manifests
+        echo -n "messaging-topology-operator-with-certmanager-${{ steps.meta.outputs.version }}.yaml" > "newest-operator-dev-manifest.txt"
     - name: Upload operator manifests
       uses: actions/upload-artifact@v4
       with:
@@ -152,15 +153,12 @@ jobs:
         path: messaging-topology-operator-with-certmanager-${{ steps.meta.outputs.version }}.yaml
         destination: operator-manifests-dev
         process_gcloudignore: false
-    - name: Trigger carvel-packaging-dev pipeline in Runway
-      uses: jghiloni/concourse-trigger-job-action@v1
+    - name: Update carvel-packaging-dev pipeline trigger
+      uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        concourse-url: https://runway-ci-sfo.eng.vmware.com/
-        concourse-team: rabbitmq
-        concourse-pipeline: dev-manifest-issue-fix
-        concourse-job: build-bundle-dev
-        concourse-username: ${secrets.RUNWAY_USERNAME}
-        concourse-password: ${secrets.RUNWAY_PASSWORD}
+        path: newest-operator-dev-manifest.txt
+        destination: operator-manifests-dev
+        process_gcloudignore: false
 
   system_tests_gke:
     name: System tests using gke

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -153,7 +153,7 @@ jobs:
         destination: operator-manifests-dev
         process_gcloudignore: false
     - name: Trigger carvel-packaging-dev pipeline in Runway
-      uses: jghiloni/trigger-concourse-job-action@v2
+      uses: actions/trigger-concourse-job-action@v1
       with:
         concourse-url: https://runway-ci-sfo.eng.vmware.com/
         concourse-team: rabbitmq

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -129,7 +129,7 @@ jobs:
         rabbitmqoperator/messaging-topology-operator-dev=rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
         popd
         make generate-manifests
-        echo -n "messaging-topology-operator-with-certmanager-${{ steps.meta.outputs.version }}.yaml" > "newest-operator-dev-manifest.txt"
+        echo -n "messaging-topology-operator-with-certmanager-${{ steps.meta.outputs.version }}.yaml" > "latest-topology-operator-dev-manifest.txt"
     - name: Upload operator manifests
       uses: actions/upload-artifact@v4
       with:
@@ -156,7 +156,7 @@ jobs:
     - name: Update carvel-packaging-dev pipeline trigger
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: newest-operator-dev-manifest.txt
+        path: latest-topology-operator-dev-manifest.txt
         destination: operator-manifests-dev
         process_gcloudignore: false
 

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -153,7 +153,7 @@ jobs:
         destination: operator-manifests-dev
         process_gcloudignore: false
     - name: Trigger carvel-packaging-dev pipeline in Runway
-      uses: actions/trigger-concourse-job-action@v2
+      uses: jghiloni/trigger-concourse-job-action@v2
       with:
         concourse-url: https://runway-ci-sfo.eng.vmware.com/
         concourse-team: rabbitmq

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -2,7 +2,7 @@ name: Build, Test, Publish Image & Manifest
 
 on:
   push:
-    branches: [ "main"]
+    branches: [ "trigger-carvel-bundle-dev-pipeline"]
     paths-ignore:
     - 'docs/**'
     - '*.md'
@@ -152,6 +152,15 @@ jobs:
         path: messaging-topology-operator-with-certmanager-${{ steps.meta.outputs.version }}.yaml
         destination: operator-manifests-dev
         process_gcloudignore: false
+    - name: Trigger carvel-packaging-dev pipeline in Runway
+      uses: actions/trigger-concourse-job-action@v2
+      with:
+        concourse-url: https://runway-ci-sfo.eng.vmware.com/
+        concourse-team: rabbitmq
+        concourse-pipeline: dev-manifest-issue-fix
+        concourse-job: build-bundle-dev
+        concourse-username: ${secrets.RUNWAY_USERNAME}
+        concourse-password: ${secrets.RUNWAY_PASSWORD}
 
   system_tests_gke:
     name: System tests using gke

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -153,7 +153,7 @@ jobs:
         destination: operator-manifests-dev
         process_gcloudignore: false
     - name: Trigger carvel-packaging-dev pipeline in Runway
-      uses: jghiloni/concourse-trigger-job-action@v2
+      uses: jghiloni/concourse-trigger-job-action@v1
       with:
         concourse-url: https://runway-ci-sfo.eng.vmware.com/
         concourse-team: rabbitmq

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -153,7 +153,7 @@ jobs:
         destination: operator-manifests-dev
         process_gcloudignore: false
     - name: Trigger carvel-packaging-dev pipeline in Runway
-      uses: actions/trigger-concourse-job-action@v1
+      uses: jghiloni/concourse-trigger-job-action@v2
       with:
         concourse-url: https://runway-ci-sfo.eng.vmware.com/
         concourse-team: rabbitmq


### PR DESCRIPTION
This closes an issue with the `RabbitMQ for Kubernetes` build CI pipeline
#https://github.com/rabbitmq/service-operator-experience/issues/174

## Summary Of Changes

The Build-Publish-Test CI workflow of this operator will now update a trigger file in GCP bucket once a dev manifest is generated for every commit into main
