### PR TITLE
small fix on testing_and_publishing_OLM_bundle

### DIFF
--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -42,6 +42,8 @@ jobs:
           run: | 
             BUNDLE_VERSION=${GITHUB_REF#refs/*/} 
             echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" >> $GITHUB_ENV
+          shell: bash
+          
         - name: Set tag image for test version
           if: startsWith(github.ref, 'refs/tags/v') == false
           run: | 


### PR DESCRIPTION
Same as https://github.com/rabbitmq/cluster-operator/pull/1603

Small fix to run that failing job in a bash shell