### PR TITLE
Don't watch secrets

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,14 +14,14 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"strconv"
 	"strings"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -230,7 +230,7 @@ func main() {
 		Recorder:                mgr.GetEventRecorderFor(controllers.UserControllerName),
 		RabbitmqClientFactory:   rabbitmqclient.RabbitholeClientFactory,
 		KubernetesClusterDomain: clusterDomain,
-		WatchTypes:              []client.Object{&corev1.Secret{}},
+		WatchTypes:              []client.Object{},
 		ReconcileFunc:           &controllers.UserReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()},
 		ConnectUsingPlainHTTP:   usePlainHTTP,
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
Watching the secrets can lead to high memory usage if there's a lot of them. It seems like we don't actually rely on this, so we can turn that off completely.

Fixes https://github.com/rabbitmq/messaging-topology-operator/issues/783
