### PR TITLE
Remove 'all' category from CRDs

### DIFF
--- a/api/v1alpha1/superstream_types.go
+++ b/api/v1alpha1/superstream_types.go
@@ -49,7 +49,7 @@ type SuperStreamStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // SuperStream is the Schema for the queues API

--- a/api/v1beta1/binding_types.go
+++ b/api/v1beta1/binding_types.go
@@ -53,7 +53,7 @@ type BindingStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Binding is the Schema for the bindings API

--- a/api/v1beta1/exchange_types.go
+++ b/api/v1beta1/exchange_types.go
@@ -49,7 +49,7 @@ type ExchangeStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Exchange is the Schema for the exchanges API

--- a/api/v1beta1/federation_types.go
+++ b/api/v1beta1/federation_types.go
@@ -47,7 +47,7 @@ type FederationStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Federation is the Schema for the federations API

--- a/api/v1beta1/operatorpolicy_types.go
+++ b/api/v1beta1/operatorpolicy_types.go
@@ -49,7 +49,7 @@ type OperatorPolicyStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // OperatorPolicy is the Schema for the operator policies API

--- a/api/v1beta1/permission_types.go
+++ b/api/v1beta1/permission_types.go
@@ -46,7 +46,7 @@ type PermissionStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Permission is the Schema for the permissions API

--- a/api/v1beta1/policy_types.go
+++ b/api/v1beta1/policy_types.go
@@ -49,7 +49,7 @@ type PolicyStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Policy is the Schema for the policies API

--- a/api/v1beta1/queue_types.go
+++ b/api/v1beta1/queue_types.go
@@ -57,7 +57,7 @@ type QueueStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Queue is the Schema for the queues API

--- a/api/v1beta1/shovel_types.go
+++ b/api/v1beta1/shovel_types.go
@@ -90,7 +90,7 @@ type ShovelStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Shovel is the Schema for the shovels API

--- a/api/v1beta1/user_types.go
+++ b/api/v1beta1/user_types.go
@@ -55,7 +55,7 @@ type UserTag string
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // User is the Schema for the users API.

--- a/api/v1beta1/vhost_types.go
+++ b/api/v1beta1/vhost_types.go
@@ -41,7 +41,7 @@ type VhostStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;rabbitmq
+// +kubebuilder:resource:categories=rabbitmq
 // +kubebuilder:subresource:status
 
 // Vhost is the Schema for the vhosts API

--- a/config/crd/bases/rabbitmq.com_bindings.yaml
+++ b/config/crd/bases/rabbitmq.com_bindings.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Binding
     listKind: BindingList

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Exchange
     listKind: ExchangeList

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Federation
     listKind: FederationList

--- a/config/crd/bases/rabbitmq.com_operatorpolicies.yaml
+++ b/config/crd/bases/rabbitmq.com_operatorpolicies.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: OperatorPolicy
     listKind: OperatorPolicyList

--- a/config/crd/bases/rabbitmq.com_permissions.yaml
+++ b/config/crd/bases/rabbitmq.com_permissions.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Permission
     listKind: PermissionList

--- a/config/crd/bases/rabbitmq.com_policies.yaml
+++ b/config/crd/bases/rabbitmq.com_policies.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Policy
     listKind: PolicyList

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Queue
     listKind: QueueList

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Shovel
     listKind: ShovelList

--- a/config/crd/bases/rabbitmq.com_superstreams.yaml
+++ b/config/crd/bases/rabbitmq.com_superstreams.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: SuperStream
     listKind: SuperStreamList

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: User
     listKind: UserList

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -9,7 +9,6 @@ spec:
   group: rabbitmq.com
   names:
     categories:
-    - all
     - rabbitmq
     kind: Vhost
     listKind: VhostList


### PR DESCRIPTION
This closes #753

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Remove our CRDs from 'all' category.

## Additional Context

Having all our CRDs in 'all' category can significantly slowdown the response time of `kubectl get all`. In addition we are not suppoused to modify 'all' category. Our CRDs are still in the 'rabbitmq' category, so that any `kubectl get rabbitmq` will return all rabbit related objects.

