### PR TITLE
Revert docker/build-push-action version due to known issue

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -94,7 +94,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true
@@ -113,7 +113,7 @@ jobs:
           type=semver,pattern={{version}},suffix=-amd64,latest=false
           type=sha,suffix=-amd64,latest=false
     - name: Build and push single-arch amd64 image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/amd64
@@ -132,7 +132,7 @@ jobs:
           type=semver,pattern={{version}},suffix=-arm64,latest=false
           type=sha,suffix=-arm64,latest=false
     - name: Build and push single-arch arm64 image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v3
       with:
         context: .
         platforms: linux/arm64

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -94,6 +94,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push
+      # Do not bump below action version (Known issue - https://github.com/docker/build-push-action/issues/820)
       uses: docker/build-push-action@v3
       with:
         context: .
@@ -113,6 +114,7 @@ jobs:
           type=semver,pattern={{version}},suffix=-amd64,latest=false
           type=sha,suffix=-amd64,latest=false
     - name: Build and push single-arch amd64 image
+      # Do not bump below action version (Known issue - https://github.com/docker/build-push-action/issues/820)
       uses: docker/build-push-action@v3
       with:
         context: .
@@ -132,6 +134,7 @@ jobs:
           type=semver,pattern={{version}},suffix=-arm64,latest=false
           type=sha,suffix=-arm64,latest=false
     - name: Build and push single-arch arm64 image
+      # Do not bump below action version (Known issue - https://github.com/docker/build-push-action/issues/820)
       uses: docker/build-push-action@v3
       with:
         context: .


### PR DESCRIPTION
Version 5 of docker/build-push-action produces `unknown` architecture and os in manifest
