### PR TITLE
small fix on testing_and_publishing_olm_bundle action

### DIFF
--- a/.github/workflows/testing_and_publishing_OLM_bundle.yml
+++ b/.github/workflows/testing_and_publishing_OLM_bundle.yml
@@ -167,6 +167,7 @@ jobs:
           run: | 
             BUNDLE_VERSION=${GITHUB_REF#refs/*/} 
             echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" >> $GITHUB_ENV
+          shell: bash
         - name: Set tag image for test version
           if: startsWith(github.ref, 'refs/tags/v') == false
           run: | 


### PR DESCRIPTION
Similarly to: https://github.com/rabbitmq/messaging-topology-operator/pull/788

This is solving a small issue in the last released (changing shell to bash):

https://github.com/rabbitmq/messaging-topology-operator/actions/runs/9033233474/job/24823384030