### PR TITLE
Regenerate user passwords when user reconciles

### DIFF
--- a/api/v1beta1/user_types.go
+++ b/api/v1beta1/user_types.go
@@ -37,6 +37,10 @@ type UserSpec struct {
 	//
 	// Note that this import only occurs at creation time, and is ignored once a password has been set on a User.
 	ImportCredentialsSecret *corev1.LocalObjectReference `json:"importCredentialsSecret,omitempty"`
+	// Feature flag to always regenerate the `-user-credentials` Secret from the ImportCredentialsSecret.
+	// Defaults to false if omitted.
+	// +kubebuilder:validation:Optional
+	AutoUpdateCredentialsSecret bool `json:"autoUpdateCredentialsSecret,omitempty"`
 }
 
 // UserStatus defines the observed state of User.

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -41,6 +41,11 @@ spec:
           spec:
             description: Spec configures the desired state of the User object.
             properties:
+              autoUpdateCredentialsSecret:
+                description: |-
+                  Feature flag to always regenerate the `-user-credentials` Secret from the ImportCredentialsSecret.
+                  Defaults to false if omitted.
+                type: boolean
               importCredentialsSecret:
                 description: |-
                   Defines a Secret containing the credentials for the User. If this field is omitted, random a username and

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -189,9 +189,9 @@ func (r *UserReconciler) setUserStatus(ctx context.Context, user *topology.User,
 func (r *UserReconciler) DeclareFunc(ctx context.Context, client rabbitmqclient.Client, obj topology.TopologyResource) error {
 	logger := ctrl.LoggerFrom(ctx)
 	user := obj.(*topology.User)
-	if user.Status.Credentials == nil || user.Status.Username == "" {
+	if user.Status.Credentials == nil || user.Status.Username == "" || user.Spec.AutoUpdateCredentialsSecret {
 		var username string
-		if user.Status.Credentials != nil && user.Status.Username == "" || user.Spec.AutoUpdateCredentialsSecret {
+		if user.Status.Credentials != nil && user.Status.Username == "" {
 			// Only run once for migration to set user.Status.Username on existing resources
 			credentials, err := r.getUserCredentials(ctx, user)
 			if err != nil {

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -1422,6 +1422,8 @@ password will be generated. The Secret must have the following keys in its Data 
 
 
 Note that this import only occurs at creation time, and is ignored once a password has been set on a User.
+| *`autoUpdateCredentialsSecret`* __boolean__ | Feature flag to always regenerate the `-user-credentials` Secret from the ImportCredentialsSecret.
+Defaults to false if omitted.
 |===
 
 


### PR DESCRIPTION
This closes #242 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
This Pull Request adds an option to always regenerate a user's user-credentials secret when a reconciliation for the user is triggered. The main use case is to update a user's password when the underlying import secret has changed.

## Additional Context
A user's login credential are stored in the user-credentials secrets, which are generated at the user creation from an import secret. The documentation instructs us to add a label to trigger user reconciliation when we want to update a users password: https://github.com/rabbitmq/messaging-topology-operator/blob/main/docs/examples/users/README.md

This does however currently not affect a regeneration of the user-credentials secret: s. issue #242 

Therefore I added these changes to allow us to force a regeneration when the user is reconciled (e.g. when a label is added).
