### PR TITLE
Update API reference and Build/Publish workflows

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -138,8 +138,6 @@ jobs:
         kustomize edit set image \
         rabbitmqoperator/messaging-topology-operator-dev=rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
         popd
-        make generate-manifests
-        echo -n "messaging-topology-operator-with-certmanager-${{ steps.meta.outputs.version }}.yaml" > "latest-topology-operator-dev-manifest.txt"
 
     - name: Upload operator manifests
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-versioned-api-ref.yml
+++ b/.github/workflows/publish-versioned-api-ref.yml
@@ -26,11 +26,15 @@ jobs:
           repository: ${{ github.repository }}.wiki
           path: wiki
 
+      - name: Generate API reference
+        run: make -C messaging-topology-operator api-reference
+
       - name: Push to wiki
+        # User and email as documented here: https://github.com/marketplace/actions/checkout#push-a-commit-using-the-built-in-token
         run: |
           cd wiki
-          git config --local user.email "github-actions@github.com"
-          git config --local user.name "github-actions"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           # Add the versioned API Reference to the Wiki
           cp ../messaging-topology-operator/docs/api/rabbitmq.com.ref.asciidoc ./API_Reference_${{ steps.get_version.outputs.VERSION }}.asciidoc
           # Regenerate the ordered list of API Reference docs for the sidebar


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- Fix API ref workflow
- Removed unused dev manifest generation

## Additional Context

The Build/Test/Publish job was commiting + pushing to the Wiki for every commit. During the re-work of that pipeline,
we stopped pushing to the Wiki for every commit. That unintentionally broke the API reference workflow. The job is green
because the commands succeed, but the outcome is not correct. The simplest solution is to generate the API reference
just before publishing to the Wiki, in the same job.

