### PR TITLE
[#922] controlling resources deletion

### DIFF
--- a/api/v1beta1/federation_types.go
+++ b/api/v1beta1/federation_types.go
@@ -35,6 +35,11 @@ type FederationSpec struct {
 	TrustUserId    bool   `json:"trustUserId,omitempty"`
 	Exchange       string `json:"exchange,omitempty"`
 	Queue          string `json:"queue,omitempty"`
+	// DeletionPolicy defines the behavior of federation in the RabbitMQ cluster when the corresponding custom resource is deleted.
+	// Can be set to 'delete' or 'retain'. Default is 'delete'.
+	// +kubebuilder:validation:Enum=delete;retain
+	// +kubebuilder:default:=delete
+	DeletionPolicy string `json:"deletionPolicy,omitempty"`
 }
 
 // FederationStatus defines the observed state of Federation

--- a/api/v1beta1/federation_webhook_test.go
+++ b/api/v1beta1/federation_webhook_test.go
@@ -115,5 +115,12 @@ var _ = Describe("federation webhook", func() {
 			_, err := newFederation.ValidateUpdate(rootCtx, &federation, newFederation)
 			Expect(err).To(Succeed())
 		})
+
+		It("allows updates on federation.spec.deletionPolicy", func() {
+			newFederation := federation.DeepCopy()
+			newFederation.Spec.DeletionPolicy = "retain"
+			_, err := newFederation.ValidateUpdate(rootCtx, &federation, newFederation)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/api/v1beta1/queue_types.go
+++ b/api/v1beta1/queue_types.go
@@ -45,6 +45,11 @@ type QueueSpec struct {
 	// Required property.
 	// +kubebuilder:validation:Required
 	RabbitmqClusterReference RabbitmqClusterReference `json:"rabbitmqClusterReference"`
+	// DeletionPolicy defines the behavior of queue in the RabbitMQ cluster when the corresponding custom resource is deleted.
+	// Can be set to 'delete' or 'retain'. Default is 'delete'.
+	// +kubebuilder:validation:Enum=delete;retain
+	// +kubebuilder:default:=delete
+	DeletionPolicy string `json:"deletionPolicy,omitempty"`
 }
 
 // QueueStatus defines the observed state of Queue

--- a/api/v1beta1/queue_webhook_test.go
+++ b/api/v1beta1/queue_webhook_test.go
@@ -154,5 +154,12 @@ var _ = Describe("queue webhook", func() {
 			_, err = newQueue.ValidateUpdate(rootCtx, &queue, newQueue)
 			Expect(err).To(MatchError(ContainSubstring("queue arguments cannot be updated")))
 		})
+
+		It("allows updates on queue.spec.deletionPolicy", func() {
+			newQueue := queue.DeepCopy()
+			newQueue.Spec.DeletionPolicy = "retain"
+			_, err := newQueue.ValidateUpdate(rootCtx, &queue, newQueue)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/api/v1beta1/shovel_types.go
+++ b/api/v1beta1/shovel_types.go
@@ -84,6 +84,11 @@ type ShovelSpec struct {
 	SourceConsumerArgs *runtime.RawExtension `json:"srcConsumerArgs,omitempty"`
 	// amqp10 configuration; required if srcProtocol is amqp10
 	SourceAddress string `json:"srcAddress,omitempty"`
+	// DeletionPolicy defines the behavior of shovel in the RabbitMQ cluster when the corresponding custom resource is deleted.
+	// Can be set to 'delete' or 'retain'. Default is 'delete'.
+	// +kubebuilder:validation:Enum=delete;retain
+	// +kubebuilder:default:=delete
+	DeletionPolicy string `json:"deletionPolicy,omitempty"`
 }
 
 // ShovelStatus defines the observed state of Shovel

--- a/api/v1beta1/shovel_webhook_test.go
+++ b/api/v1beta1/shovel_webhook_test.go
@@ -179,5 +179,12 @@ var _ = Describe("shovel webhook", func() {
 			_, err := newShovel.ValidateUpdate(rootCtx, &shovel, newShovel)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("allows updates on shovel.spec.deletionPolicy", func() {
+			newShovel := shovel.DeepCopy()
+			newShovel.Spec.DeletionPolicy = "retain"
+			_, err := newShovel.ValidateUpdate(rootCtx, &shovel, newShovel)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/api/v1beta1/vhost_types.go
+++ b/api/v1beta1/vhost_types.go
@@ -29,6 +29,11 @@ type VhostSpec struct {
 	// Required property.
 	// +kubebuilder:validation:Required
 	RabbitmqClusterReference RabbitmqClusterReference `json:"rabbitmqClusterReference"`
+	// DeletionPolicy defines the behavior of vhost in the RabbitMQ cluster when the corresponding custom resource is deleted.
+	// Can be set to 'delete' or 'retain'. Default is 'delete'.
+	// +kubebuilder:validation:Enum=delete;retain
+	// +kubebuilder:default:=delete
+	DeletionPolicy string `json:"deletionPolicy,omitempty"`
 }
 
 // VhostStatus defines the observed state of Vhost

--- a/api/v1beta1/vhost_webhook_test.go
+++ b/api/v1beta1/vhost_webhook_test.go
@@ -102,5 +102,12 @@ var _ = Describe("vhost webhook", func() {
 			_, err := newVhost.ValidateUpdate(rootCtx, &vhost, newVhost)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("allows updates on vhost.spec.deletionPolicy", func() {
+			newVhost := vhost.DeepCopy()
+			newVhost.Spec.DeletionPolicy = "retain"
+			_, err := newVhost.ValidateUpdate(rootCtx, &vhost, newVhost)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/config/crd/bases/rabbitmq.com_federations.yaml
+++ b/config/crd/bases/rabbitmq.com_federations.yaml
@@ -49,6 +49,15 @@ spec:
                 - on-publish
                 - no-ack
                 type: string
+              deletionPolicy:
+                default: delete
+                description: |-
+                  DeletionPolicy defines the behavior of federation in the RabbitMQ cluster when the corresponding custom resource is deleted.
+                  Can be set to 'delete' or 'retain'. Default is 'delete'.
+                enum:
+                - delete
+                - retain
+                type: string
               exchange:
                 type: string
               expires:

--- a/config/crd/bases/rabbitmq.com_queues.yaml
+++ b/config/crd/bases/rabbitmq.com_queues.yaml
@@ -58,6 +58,15 @@ spec:
                 description: when set to true, queues are delete only if they have
                   no consumer.
                 type: boolean
+              deletionPolicy:
+                default: delete
+                description: |-
+                  DeletionPolicy defines the behavior of queue in the RabbitMQ cluster when the corresponding custom resource is deleted.
+                  Can be set to 'delete' or 'retain'. Default is 'delete'.
+                enum:
+                - delete
+                - retain
+                type: string
               durable:
                 description: When set to false queues does not survive server restart.
                 type: boolean

--- a/config/crd/bases/rabbitmq.com_shovels.yaml
+++ b/config/crd/bases/rabbitmq.com_shovels.yaml
@@ -53,6 +53,15 @@ spec:
                 type: boolean
               deleteAfter:
                 type: string
+              deletionPolicy:
+                default: delete
+                description: |-
+                  DeletionPolicy defines the behavior of shovel in the RabbitMQ cluster when the corresponding custom resource is deleted.
+                  Can be set to 'delete' or 'retain'. Default is 'delete'.
+                enum:
+                - delete
+                - retain
+                type: string
               destAddForwardHeaders:
                 type: boolean
               destAddTimestampHeader:

--- a/config/crd/bases/rabbitmq.com_vhosts.yaml
+++ b/config/crd/bases/rabbitmq.com_vhosts.yaml
@@ -50,6 +50,15 @@ spec:
                 - classic
                 - stream
                 type: string
+              deletionPolicy:
+                default: delete
+                description: |-
+                  DeletionPolicy defines the behavior of vhost in the RabbitMQ cluster when the corresponding custom resource is deleted.
+                  Can be set to 'delete' or 'retain'. Default is 'delete'.
+                enum:
+                - delete
+                - retain
+                type: string
               name:
                 description: Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
                 type: string

--- a/controllers/federation_controller.go
+++ b/controllers/federation_controller.go
@@ -54,6 +54,9 @@ func (r *FederationReconciler) getUri(ctx context.Context, federation *topology.
 func (r *FederationReconciler) DeleteFunc(ctx context.Context, client rabbitmqclient.Client, obj topology.TopologyResource) error {
 	logger := ctrl.LoggerFrom(ctx)
 	federation := obj.(*topology.Federation)
+	if shouldSkipDeletion(ctx, federation.Spec.DeletionPolicy, federation.Spec.Name) {
+		return nil
+	}
 	err := validateResponseForDeletion(client.DeleteFederationUpstream(federation.Spec.Vhost, federation.Spec.Name))
 	if errors.Is(err, NotFound) {
 		logger.Info("cannot find federation upstream parameter; no need to delete it", "federation", federation.Spec.Name)

--- a/controllers/queue_controller.go
+++ b/controllers/queue_controller.go
@@ -47,6 +47,9 @@ func (r *QueueReconciler) DeleteFunc(ctx context.Context, client rabbitmqclient.
 	logger.Info("Deleting queues from ReconcilerFunc DeleteObj")
 
 	queue := obj.(*topology.Queue)
+	if shouldSkipDeletion(ctx, queue.Spec.DeletionPolicy, queue.Spec.Name) {
+		return nil
+	}
 	queueDeleteOptions, err := internal.GenerateQueueDeleteOptions(queue)
 	if err != nil {
 		return fmt.Errorf("failed to generate queue delete options: %w", err)

--- a/controllers/shovel_controller.go
+++ b/controllers/shovel_controller.go
@@ -62,6 +62,9 @@ func (r *ShovelReconciler) getUris(ctx context.Context, shovel *topology.Shovel)
 func (r *ShovelReconciler) DeleteFunc(ctx context.Context, client rabbitmqclient.Client, obj topology.TopologyResource) error {
 	logger := ctrl.LoggerFrom(ctx)
 	shovel := obj.(*topology.Shovel)
+	if shouldSkipDeletion(ctx, shovel.Spec.DeletionPolicy, shovel.Spec.Name) {
+		return nil
+	}
 	err := validateResponseForDeletion(client.DeleteShovel(shovel.Spec.Vhost, shovel.Spec.Name))
 	if errors.Is(err, NotFound) {
 		logger.Info("cannot find shovel parameter; no need to delete it", "shovel", shovel.Spec.Name)

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -128,3 +128,13 @@ func handleRMQReferenceParseError(ctx context.Context, client client.Client, eve
 	logger.Error(err, failedParseClusterRef)
 	return reconcile.Result{}, err
 }
+
+// shouldSkipDeletion checks the DeletionPolicy and logs if deletion should be skipped.
+func shouldSkipDeletion(ctx context.Context, deletionPolicy string, resourceName string) bool {
+	logger := ctrl.LoggerFrom(ctx)
+	if deletionPolicy == "retain" {
+		logger.Info("Skipping deletion in RabbitMQ server due to deletionPolicy=retain", "resource", resourceName)
+		return true
+	}
+	return false
+}

--- a/controllers/vhost_controller.go
+++ b/controllers/vhost_controller.go
@@ -30,6 +30,9 @@ func (r *VhostReconciler) DeclareFunc(_ context.Context, client rabbitmqclient.C
 func (r *VhostReconciler) DeleteFunc(ctx context.Context, client rabbitmqclient.Client, obj topology.TopologyResource) error {
 	logger := ctrl.LoggerFrom(ctx)
 	vhost := obj.(*topology.Vhost)
+	if shouldSkipDeletion(ctx, vhost.Spec.DeletionPolicy, vhost.Spec.Name) {
+		return nil
+	}
 	err := validateResponseForDeletion(client.DeleteVhost(vhost.Spec.Name))
 	if errors.Is(err, NotFound) {
 		logger.Info("cannot find vhost in rabbitmq server; already deleted", "vhost", vhost.Spec.Name)

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -494,6 +494,8 @@ Required property.
 | *`trustUserId`* __boolean__ | 
 | *`exchange`* __string__ | 
 | *`queue`* __string__ | 
+| *`deletionPolicy`* __string__ | DeletionPolicy defines the behavior of federation in the RabbitMQ cluster when the corresponding custom resource is deleted.
+Can be set to 'delete' or 'retain'. Default is 'delete'.
 |===
 
 
@@ -908,6 +910,8 @@ QueueSpec defines the desired state of Queue
 Configuring queues through arguments is not recommended because they cannot be updated once set; we recommend configuring queues through policies instead.
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the queue will be created in.
 Required property.
+| *`deletionPolicy`* __string__ | DeletionPolicy defines the behavior of queue in the RabbitMQ cluster when the corresponding custom resource is deleted.
+Can be set to 'delete' or 'retain'. Default is 'delete'.
 |===
 
 
@@ -1193,6 +1197,8 @@ Required property.
 | *`srcExchangeKey`* __string__ | amqp091 configuration
 | *`srcConsumerArgs`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rawextension-runtime-pkg[$$RawExtension$$]__ | amqp091 configuration
 | *`srcAddress`* __string__ | amqp10 configuration; required if srcProtocol is amqp10
+| *`deletionPolicy`* __string__ | DeletionPolicy defines the behavior of shovel in the RabbitMQ cluster when the corresponding custom resource is deleted.
+Can be set to 'delete' or 'retain'. Default is 'delete'.
 |===
 
 
@@ -1577,6 +1583,8 @@ VhostSpec defines the desired state of Vhost
 Supported in RabbitMQ 3.11.12 or above.
 | *`rabbitmqClusterReference`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-rabbitmqclusterreference[$$RabbitmqClusterReference$$]__ | Reference to the RabbitmqCluster that the vhost will be created in.
 Required property.
+| *`deletionPolicy`* __string__ | DeletionPolicy defines the behavior of vhost in the RabbitMQ cluster when the corresponding custom resource is deleted.
+Can be set to 'delete' or 'retain'. Default is 'delete'.
 |===
 
 

--- a/docs/examples/federations/federation.yaml
+++ b/docs/examples/federations/federation.yaml
@@ -9,5 +9,6 @@ spec:
   uriSecret:
     name: federation-uri
   ackMode: "on-confirm"
+  deletionPolicy: retain # delete or retain; default to delete;
   rabbitmqClusterReference:
     name: example-rabbit

--- a/docs/examples/queues/quorum-queue.yaml
+++ b/docs/examples/queues/quorum-queue.yaml
@@ -11,6 +11,7 @@ spec:
   type: quorum # without providing a queue type, rabbitmq creates a classic queue
   autoDelete: false
   durable: true # seting 'durable' to false means this queue won't survive a server restart
+  deletionPolicy: retain # delete or retain; default to delete;
   rabbitmqClusterReference:
     name: test # rabbitmqCluster must exist in the same namespace as this resource
 # status:

--- a/docs/examples/queues/stream-queue.yaml
+++ b/docs/examples/queues/stream-queue.yaml
@@ -9,5 +9,6 @@ spec:
   durable: true # mandatory for stream queues
   arguments:
     x-max-length-bytes: 1000000000 ## setting the retention policy
+  deletionPolicy: retain # delete or retain; default to delete;
   rabbitmqClusterReference:
       name: test # rabbitmqCluster must exist in the same namespace as this resource

--- a/docs/examples/shovels/shovel.yaml
+++ b/docs/examples/shovels/shovel.yaml
@@ -14,5 +14,6 @@ spec:
   destQueue: "destination-queue"
   destPublishProperties: # optional map of properties to overwrite when shovelling messages
     delivery_mode: 2
+  deletionPolicy: retain # delete or retain; default to delete;
   rabbitmqClusterReference:
     name: example-rabbit

--- a/docs/examples/vhosts/vhost.yaml
+++ b/docs/examples/vhosts/vhost.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   name: test-vhost # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  deletionPolicy: retain # delete or retain; default to delete;
   rabbitmqClusterReference:
     name: test # rabbitmqCluster must exist in the same namespace as this resource
 # status:

--- a/system_tests/federation_system_test.go
+++ b/system_tests/federation_system_test.go
@@ -126,42 +126,44 @@ var _ = Describe("federation", func() {
 		Expect(err.Error()).To(ContainSubstring("Object Not Found"))
 	})
 
-	It("with DeletionPolicy=retain, deletes k8s resource but keeps the federation in RabbitMQ", func() {
-		federationWithRetain := &topology.Federation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "retain-policy-test",
-				Namespace: namespace,
-			},
-			Spec: topology.FederationSpec{
-				Name:           "retain-policy-test",
-				UriSecret:      &corev1.LocalObjectReference{Name: federationUriSecret.Name},
-				DeletionPolicy: "retain",
-				RabbitmqClusterReference: topology.RabbitmqClusterReference{
-					Name: rmq.Name,
+	When("deletion policy is retain", func() {
+		It("deletes k8s resource but keeps the federation in RabbitMQ", func() {
+			federationWithRetain := &topology.Federation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "retain-policy-test",
+					Namespace: namespace,
 				},
-			},
-		}
+				Spec: topology.FederationSpec{
+					Name:           "retain-policy-test",
+					UriSecret:      &corev1.LocalObjectReference{Name: federationUriSecret.Name},
+					DeletionPolicy: "retain",
+					RabbitmqClusterReference: topology.RabbitmqClusterReference{
+						Name: rmq.Name,
+					},
+				},
+			}
 
-		By("creating a federation with retain policy")
-		Expect(k8sClient.Create(ctx, federationWithRetain, &client.CreateOptions{})).To(Succeed())
+			By("creating a federation with retain policy")
+			Expect(k8sClient.Create(ctx, federationWithRetain, &client.CreateOptions{})).To(Succeed())
 
-		By("waiting for the federation to be created in RabbitMQ")
-		Eventually(func() error {
+			By("waiting for the federation to be created in RabbitMQ")
+			Eventually(func() error {
+				_, err := rabbitClient.GetFederationUpstream("/", federationWithRetain.Spec.Name)
+				return err
+			}, 30, 2).ShouldNot(HaveOccurred())
+
+			By("deleting the k8s resource")
+			Expect(k8sClient.Delete(ctx, federationWithRetain)).To(Succeed())
+
+			By("verifying k8s resource is gone")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: federationWithRetain.Name, Namespace: federationWithRetain.Namespace}, &topology.Federation{})
+				return apierrors.IsNotFound(err)
+			}, 30, 2).Should(BeTrue())
+
+			By("verifying federation still exists in RabbitMQ")
 			_, err := rabbitClient.GetFederationUpstream("/", federationWithRetain.Spec.Name)
-			return err
-		}, 30, 2).ShouldNot(HaveOccurred())
-
-		By("deleting the k8s resource")
-		Expect(k8sClient.Delete(ctx, federationWithRetain)).To(Succeed())
-
-		By("verifying k8s resource is gone")
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: federationWithRetain.Name, Namespace: federationWithRetain.Namespace}, &topology.Federation{})
-			return apierrors.IsNotFound(err)
-		}, 30, 2).Should(BeTrue())
-
-		By("verifying federation still exists in RabbitMQ")
-		_, err := rabbitClient.GetFederationUpstream("/", federationWithRetain.Spec.Name)
-		Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })

--- a/system_tests/queue_system_test.go
+++ b/system_tests/queue_system_test.go
@@ -103,43 +103,45 @@ var _ = Describe("Queue Controller", func() {
 		Expect(err.Error()).To(ContainSubstring("Object Not Found"))
 	})
 
-	It("with DeletionPolicy=retain, deletes k8s resource but keeps the queue in RabbitMQ", func() {
-		queueWithRetain := &topology.Queue{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "retain-policy-test",
-				Namespace: namespace,
-			},
-			Spec: topology.QueueSpec{
-				Name:           "retain-policy-test",
-				Type:           "classic",
-				Durable:        true,
-				DeletionPolicy: "retain",
-				RabbitmqClusterReference: topology.RabbitmqClusterReference{
-					Name: rmq.Name,
+	When("deletion policy is retain", func() {
+		It("deletes k8s resource but keeps the queue in RabbitMQ", func() {
+			queueWithRetain := &topology.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "retain-policy-test",
+					Namespace: namespace,
 				},
-			},
-		}
+				Spec: topology.QueueSpec{
+					Name:           "retain-policy-test",
+					Type:           "classic",
+					Durable:        true,
+					DeletionPolicy: "retain",
+					RabbitmqClusterReference: topology.RabbitmqClusterReference{
+						Name: rmq.Name,
+					},
+				},
+			}
 
-		By("creating a queue with retain policy")
-		Expect(k8sClient.Create(ctx, queueWithRetain, &client.CreateOptions{})).To(Succeed())
+			By("creating a queue with retain policy")
+			Expect(k8sClient.Create(ctx, queueWithRetain, &client.CreateOptions{})).To(Succeed())
 
-		By("waiting for the queue to be created in RabbitMQ")
-		Eventually(func() error {
+			By("waiting for the queue to be created in RabbitMQ")
+			Eventually(func() error {
+				_, err := rabbitClient.GetQueue("/", queueWithRetain.Spec.Name)
+				return err
+			}, 30, 2).ShouldNot(HaveOccurred())
+
+			By("deleting the k8s resource")
+			Expect(k8sClient.Delete(ctx, queueWithRetain)).To(Succeed())
+
+			By("verifying k8s resource is gone")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: queueWithRetain.Name, Namespace: queueWithRetain.Namespace}, &topology.Queue{})
+				return apierrors.IsNotFound(err)
+			}, 30, 2).Should(BeTrue())
+
+			By("verifying queue still exists in RabbitMQ")
 			_, err := rabbitClient.GetQueue("/", queueWithRetain.Spec.Name)
-			return err
-		}, 30, 2).ShouldNot(HaveOccurred())
-
-		By("deleting the k8s resource")
-		Expect(k8sClient.Delete(ctx, queueWithRetain)).To(Succeed())
-
-		By("verifying k8s resource is gone")
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: queueWithRetain.Name, Namespace: queueWithRetain.Namespace}, &topology.Queue{})
-			return apierrors.IsNotFound(err)
-		}, 30, 2).Should(BeTrue())
-
-		By("verifying queue still exists in RabbitMQ")
-		_, err := rabbitClient.GetQueue("/", queueWithRetain.Spec.Name)
-		Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })

--- a/system_tests/queue_system_test.go
+++ b/system_tests/queue_system_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 
 	topology "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("Queue Controller", func() {
@@ -100,5 +101,45 @@ var _ = Describe("Queue Controller", func() {
 			return err
 		}, 30).Should(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Object Not Found"))
+	})
+
+	It("with DeletionPolicy=retain, deletes k8s resource but keeps the queue in RabbitMQ", func() {
+		queueWithRetain := &topology.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "retain-policy-test",
+				Namespace: namespace,
+			},
+			Spec: topology.QueueSpec{
+				Name:           "retain-policy-test",
+				Type:           "classic",
+				Durable:        true,
+				DeletionPolicy: "retain",
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: rmq.Name,
+				},
+			},
+		}
+
+		By("creating a queue with retain policy")
+		Expect(k8sClient.Create(ctx, queueWithRetain, &client.CreateOptions{})).To(Succeed())
+
+		By("waiting for the queue to be created in RabbitMQ")
+		Eventually(func() error {
+			_, err := rabbitClient.GetQueue("/", queueWithRetain.Spec.Name)
+			return err
+		}, 30, 2).ShouldNot(HaveOccurred())
+
+		By("deleting the k8s resource")
+		Expect(k8sClient.Delete(ctx, queueWithRetain)).To(Succeed())
+
+		By("verifying k8s resource is gone")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: queueWithRetain.Name, Namespace: queueWithRetain.Namespace}, &topology.Queue{})
+			return apierrors.IsNotFound(err)
+		}, 30, 2).Should(BeTrue())
+
+		By("verifying queue still exists in RabbitMQ")
+		_, err := rabbitClient.GetQueue("/", queueWithRetain.Spec.Name)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/system_tests/vhost_system_test.go
+++ b/system_tests/vhost_system_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	topology "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("vhost", func() {
@@ -97,5 +98,43 @@ var _ = Describe("vhost", func() {
 			return err
 		}, 30).Should(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Object Not Found"))
+	})
+
+	It("with DeletionPolicy=retain, deletes k8s resource but keeps the vhost in RabbitMQ", func() {
+		vhostWithRetain := &topology.Vhost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "retain-policy-test",
+				Namespace: namespace,
+			},
+			Spec: topology.VhostSpec{
+				Name:           "retain-policy-test",
+				DeletionPolicy: "retain",
+				RabbitmqClusterReference: topology.RabbitmqClusterReference{
+					Name: rmq.Name,
+				},
+			},
+		}
+
+		By("creating a vhost with retain policy")
+		Expect(k8sClient.Create(ctx, vhostWithRetain, &client.CreateOptions{})).To(Succeed())
+
+		By("waiting for the vhost to be created in RabbitMQ")
+		Eventually(func() error {
+			_, err := rabbitClient.GetVhost(vhostWithRetain.Spec.Name)
+			return err
+		}, 30, 2).ShouldNot(HaveOccurred())
+
+		By("deleting the k8s resource")
+		Expect(k8sClient.Delete(ctx, vhostWithRetain)).To(Succeed())
+
+		By("verifying k8s resource is gone")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: vhostWithRetain.Name, Namespace: vhostWithRetain.Namespace}, &topology.Vhost{})
+			return apierrors.IsNotFound(err)
+		}, 30, 2).Should(BeTrue())
+
+		By("verifying vhost still exists in RabbitMQ")
+		_, err := rabbitClient.GetVhost(vhostWithRetain.Spec.Name)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
This closes #922 

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
DeletionPolicy was added to `Federation`, `Queue`, `Shovel`, and `Vhost` resources. It controls whether resource in RabbitMQ cluster is removed when custom resource is deleted.
 The deletionPolicy can be set to:  
* `delete`: The resource will be removed from RabbitMQ cluster when the custom resource deleted (default)
* `retain`: The resource will remain in RabbitMQ cluster when the custom resource deleted

## Additional Context
Change is result of [issue 922](https://github.com/rabbitmq/messaging-topology-operator/issues/922)
Corresponding PR in RabbitMQ website repo