### PR TITLE
Add flake retries to integration tests in CI.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -46,7 +46,7 @@ jobs:
       run: make install-tools kubebuilder-assets just-unit-tests
 
     - name: Integration tests
-      run: make integration-tests
+      run: GINKGO_EXTRA="--flake-attempts=3" make integration-tests
 
     - name: Notify Google Chat
       if: failure()


### PR DESCRIPTION
Integration tests are extremely flakey in github actions. This is a workaround, but ideally we should fix the integration test flakes.