### PR TITLE
Fix flakes in integration suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ export KUBEBUILDER_ASSETS = $(LOCAL_TESTBIN)/k8s/$(ENVTEST_K8S_VERSION)-$(platfo
 
 .PHONY: kubebuilder-assets
 kubebuilder-assets: $(KUBEBUILDER_ASSETS)
+	@echo "export KUBEBUILDER_ASSETS = $(LOCAL_TESTBIN)/k8s/$(ENVTEST_K8S_VERSION)-$(platform)-$(ARCHITECTURE)"
 
 $(KUBEBUILDER_ASSETS):
 	setup-envtest --os $(platform) --arch $(ARCHITECTURE) --bin-dir $(LOCAL_TESTBIN) use $(ENVTEST_K8S_VERSION)
@@ -73,6 +74,8 @@ $(YTT): | $(LOCAL_BIN)
 ##############
 #### Tests ###
 ##############
+GINKGO := go run github.com/onsi/ginkgo/v2/ginkgo
+
 .PHONY: unit-tests
 unit-tests::install-tools ## Run unit tests
 unit-tests::$(KUBEBUILDER_ASSETS)
@@ -84,7 +87,7 @@ unit-tests::just-unit-tests
 
 .PHONY: just-unit-tests
 just-unit-tests:
-	ginkgo -r --randomize-all api/ internal/ rabbitmqclient/
+	$(GINKGO) -r --randomize-all api/ internal/ rabbitmqclient/
 
 .PHONY: integration-tests
 integration-tests::install-tools ## Run integration tests. Use GINKGO_EXTRA="-some-arg" to append arguments to 'ginkgo run'
@@ -96,14 +99,14 @@ integration-tests::manifests
 integration-tests::just-integration-tests
 
 just-integration-tests: $(KUBEBUILDER_ASSETS)
-	ginkgo --randomize-all -r -p $(GINKGO_EXTRA) controllers/
+	$(GINKGO) --randomize-all -r -p $(GINKGO_EXTRA) controllers/
 
 .PHONY: local-tests
 local-tests: unit-tests integration-tests ## Run all local tests (unit & integration)
 
 .PHONY: system-tests
 system-tests: ## Run E2E tests using current context in ~/.kube/config. Expects cluster operator and topology operator to be installed in the cluster
-	NAMESPACE="rabbitmq-system" ginkgo --randomize-all -r $(GINKGO_EXTRA) system_tests/
+	NAMESPACE="rabbitmq-system" $(GINKGO) --randomize-all -r $(GINKGO_EXTRA) system_tests/
 
 
 ###################

--- a/controllers/federation_controller_test.go
+++ b/controllers/federation_controller_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	"github.com/rabbitmq/messaging-topology-operator/controllers"
 	"io"
+	"k8s.io/apimachinery/pkg/labels"
 	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -34,14 +37,29 @@ var _ = Describe("federation-controller", func() {
 		k8sClient      runtimeClient.Client
 	)
 
-	BeforeEach(func() {
+	initialiseManager := func(keyValPair ...string) {
+		var sel labels.Selector
+		if len(keyValPair) == 2 {
+			var err error
+			sel, err = labels.Parse(fmt.Sprintf("%s == %s", keyValPair[0], keyValPair[1]))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		var err error
 		federationMgr, err = ctrl.NewManager(testEnv.Config, ctrl.Options{
 			Metrics: server.Options{
 				BindAddress: "0", // To avoid MacOS firewall pop-up every time you run this suite
 			},
 			Cache: cache.Options{
-				DefaultNamespaces: map[string]cache.Config{federationNamespace: {}},
+				DefaultNamespaces: map[string]cache.Config{federationNamespace: {
+					LabelSelector: sel,
+				}},
+				ByObject: map[runtimeClient.Object]cache.ByObject{
+					// Not sure why, but restricting the NS to the test-ns fails the tests :shrug:
+					&v1beta1.RabbitmqCluster{}: {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}},
+					&corev1.Secret{}:           {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}},
+					&corev1.Service{}:          {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}},
+				},
 			},
 			Logger: GinkgoLogr,
 			Controller: config.Controller{
@@ -66,21 +84,9 @@ var _ = Describe("federation-controller", func() {
 			RabbitmqClientFactory: fakeRabbitMQClientFactory,
 			ReconcileFunc:         &controllers.FederationReconciler{Client: federationMgr.GetClient()},
 		}).SetupWithManager(federationMgr)).To(Succeed())
-	})
+	}
 
-	AfterEach(func() {
-		managerCancel()
-		// Sad workaround to avoid controllers racing for the reconciliation of other's
-		// test cases. Without this wait, the last run test consistently fails because
-		// the previous cancelled manager is just in time to reconcile the Queue of the
-		// new/last test, and use the wrong/unexpected arguments in the queue declare call
-		//
-		// Eventual consistency is nice when you have good means of awaiting. That's not the
-		// case with testenv and kubernetes controllers.
-		<-time.After(time.Second)
-	})
-
-	JustBeforeEach(func() {
+	initialiseFederation := func() {
 		federation = topology.Federation{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      federationName,
@@ -95,6 +101,18 @@ var _ = Describe("federation-controller", func() {
 				},
 			},
 		}
+	}
+
+	AfterEach(func() {
+		managerCancel()
+		// Sad workaround to avoid controllers racing for the reconciliation of other's
+		// test cases. Without this wait, the last run test consistently fails because
+		// the previous cancelled manager is just in time to reconcile the Queue of the
+		// new/last test, and use the wrong/unexpected arguments in the queue declare call
+		//
+		// Eventual consistency is nice when you have good means of awaiting. That's not the
+		// case with testenv and kubernetes controllers.
+		<-time.After(time.Second)
 	})
 
 	When("creation", func() {
@@ -109,6 +127,9 @@ var _ = Describe("federation-controller", func() {
 					Status:     "418 I'm a teapot",
 					StatusCode: 418,
 				}, errors.New("some HTTP error"))
+				initialiseFederation()
+				federation.Labels = map[string]string{"test": "test-federation-http-error"}
+				initialiseManager("test", "test-federation-http-error")
 			})
 
 			It("sets the status condition to indicate a failure to reconcile", func() {
@@ -137,6 +158,9 @@ var _ = Describe("federation-controller", func() {
 			BeforeEach(func() {
 				federationName = "test-federation-go-error"
 				fakeRabbitMQClient.PutFederationUpstreamReturns(nil, errors.New("some go failure here"))
+				initialiseFederation()
+				federation.Labels = map[string]string{"test": "test-federation-go-error"}
+				initialiseManager("test", "test-federation-go-error")
 			})
 
 			It("sets the status condition to indicate a failure to reconcile", func() {
@@ -164,6 +188,8 @@ var _ = Describe("federation-controller", func() {
 
 	When("deletion", func() {
 		JustBeforeEach(func() {
+			// Must use a JustBeforeEach to extract this common behaviour
+			// JustBeforeEach runs AFTER all BeforeEach have completed
 			fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{
 				Status:     "201 Created",
 				StatusCode: http.StatusCreated,
@@ -195,6 +221,9 @@ var _ = Describe("federation-controller", func() {
 					StatusCode: http.StatusBadGateway,
 					Body:       io.NopCloser(bytes.NewBufferString("Hello World")),
 				}, nil)
+				initialiseFederation()
+				federation.Labels = map[string]string{"test": "delete-federation-http-error"}
+				initialiseManager("test", "delete-federation-http-error")
 			})
 
 			It("raises an event to indicate a failure to delete", func() {
@@ -214,6 +243,9 @@ var _ = Describe("federation-controller", func() {
 			BeforeEach(func() {
 				federationName = "delete-federation-go-error"
 				fakeRabbitMQClient.DeleteFederationUpstreamReturns(nil, errors.New("some error"))
+				initialiseFederation()
+				federation.Labels = map[string]string{"test": "delete-federation-go-error"}
+				initialiseManager("test", "delete-federation-go-error")
 			})
 
 			It("publishes a 'warning' event", func() {
@@ -238,6 +270,9 @@ var _ = Describe("federation-controller", func() {
 				StatusCode: http.StatusOK,
 			}, nil)
 			fakeRabbitMQClient.PutFederationUpstreamReturns(&http.Response{StatusCode: http.StatusCreated, Status: "201 Created"}, nil)
+			initialiseFederation()
+			federation.Labels = map[string]string{"test": "federation-with-retain-policy"}
+			initialiseManager("test", "federation-with-retain-policy")
 		})
 
 		It("deletes the k8s resource but preserves the federation in RabbitMQ server", func() {

--- a/controllers/queue_controller_test.go
+++ b/controllers/queue_controller_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	"io"
+	"k8s.io/apimachinery/pkg/labels"
 	"net/http"
 	"time"
 
@@ -35,14 +38,28 @@ var _ = Describe("queue-controller", func() {
 		k8sClient     runtimeClient.Client
 	)
 
-	BeforeEach(func() {
+	initialiseManager := func(keyValPair ...string) {
+		var sel labels.Selector
+		if len(keyValPair) == 2 {
+			var err error
+			sel, err = labels.Parse(fmt.Sprintf("%s == %s", keyValPair[0], keyValPair[1]))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		var err error
 		queueMgr, err = ctrl.NewManager(testEnv.Config, ctrl.Options{
 			Metrics: server.Options{
 				BindAddress: "0", // To avoid MacOS firewall pop-up every time you run this suite
 			},
 			Cache: cache.Options{
-				DefaultNamespaces: map[string]cache.Config{queueNamespace: {}},
+				DefaultNamespaces: map[string]cache.Config{queueNamespace: {
+					LabelSelector: sel,
+				}},
+				ByObject: map[runtimeClient.Object]cache.ByObject{
+					&v1beta1.RabbitmqCluster{}: {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}},
+					&corev1.Secret{}:           {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}},
+					&corev1.Service{}:          {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}},
+				},
 			},
 			Logger: GinkgoLogr,
 			Controller: config.Controller{
@@ -67,21 +84,9 @@ var _ = Describe("queue-controller", func() {
 			RabbitmqClientFactory: fakeRabbitMQClientFactory,
 			ReconcileFunc:         &controllers.QueueReconciler{},
 		}).SetupWithManager(queueMgr)).To(Succeed())
-	})
+	}
 
-	AfterEach(func() {
-		managerCancel()
-		// Sad workaround to avoid controllers racing for the reconciliation of other's
-		// test cases. Without this wait, the last run test consistently fails because
-		// the previous cancelled manager is just in time to reconcile the Queue of the
-		// new/last test, and use the wrong/unexpected arguments in the queue declare call
-		//
-		// Eventual consistency is nice when you have good means of awaiting. That's not the
-		// case with testenv and kubernetes controllers.
-		<-time.After(time.Second)
-	})
-
-	JustBeforeEach(func() {
+	initialiseQueue := func() {
 		queue = topology.Queue{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      queueName,
@@ -93,6 +98,18 @@ var _ = Describe("queue-controller", func() {
 				},
 			},
 		}
+	}
+
+	AfterEach(func() {
+		managerCancel()
+		// Sad workaround to avoid controllers racing for the reconciliation of other's
+		// test cases. Without this wait, the last run test consistently fails because
+		// the previous cancelled manager is just in time to reconcile the Queue of the
+		// new/last test, and use the wrong/unexpected arguments in the queue declare call
+		//
+		// Eventual consistency is nice when you have good means of awaiting. That's not the
+		// case with testenv and kubernetes controllers.
+		<-time.After(time.Second)
 	})
 
 	Context("creation", func() {
@@ -107,6 +124,9 @@ var _ = Describe("queue-controller", func() {
 					Status:     "418 I'm a teapot",
 					StatusCode: 418,
 				}, errors.New("a failure"))
+				initialiseQueue()
+				queue.Labels = map[string]string{"test": "test-http-error"}
+				initialiseManager("test", "test-http-error")
 			})
 
 			It("sets the status condition", func() {
@@ -135,6 +155,9 @@ var _ = Describe("queue-controller", func() {
 			BeforeEach(func() {
 				queueName = "test-go-error"
 				fakeRabbitMQClient.DeclareQueueReturns(nil, errors.New("a go failure"))
+				initialiseQueue()
+				queue.Labels = map[string]string{"test": "test-go-error"}
+				initialiseManager("test", "test-go-error")
 			})
 
 			It("sets the status condition to indicate a failure to reconcile", func() {
@@ -162,6 +185,8 @@ var _ = Describe("queue-controller", func() {
 
 	Context("deletion", func() {
 		JustBeforeEach(func() {
+			// Must use a JustBeforeEach to extract this common behaviour
+			// JustBeforeEach runs AFTER all BeforeEach have completed
 			fakeRabbitMQClient.DeclareQueueReturns(&http.Response{
 				Status:     "201 Created",
 				StatusCode: http.StatusCreated,
@@ -193,6 +218,9 @@ var _ = Describe("queue-controller", func() {
 					StatusCode: http.StatusBadGateway,
 					Body:       io.NopCloser(bytes.NewBufferString("Hello World")),
 				}, nil)
+				initialiseQueue()
+				queue.Labels = map[string]string{"test": "delete-queue-http-error"}
+				initialiseManager("test", "delete-queue-http-error")
 			})
 
 			It("publishes a 'warning' event", func() {
@@ -211,6 +239,9 @@ var _ = Describe("queue-controller", func() {
 			BeforeEach(func() {
 				queueName = "delete-go-error"
 				fakeRabbitMQClient.DeleteQueueReturns(nil, errors.New("some error"))
+				initialiseQueue()
+				queue.Labels = map[string]string{"test": "delete-go-error"}
+				initialiseManager("test", "delete-go-error")
 			})
 
 			It("publishes a 'warning' event", func() {
@@ -233,6 +264,9 @@ var _ = Describe("queue-controller", func() {
 				Status:     "200 OK",
 				StatusCode: http.StatusOK,
 			}, nil)
+			initialiseQueue()
+			queue.Labels = map[string]string{"test": "queue-with-retain-policy"}
+			initialiseManager("test", "queue-with-retain-policy")
 		})
 
 		It("deletes the k8s resource but preserves the queue in RabbitMQ server", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -112,7 +112,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     operatorCrds,
 		ErrorIfCRDPathMissing: true,
 		Config: &rest.Config{
-			Host: fmt.Sprintf("localhost:818%d", GinkgoParallelProcess()),
+			Host: fmt.Sprintf("localhost:218%d", GinkgoParallelProcess()),
 		},
 	}
 

--- a/controllers/vhost_controller_test.go
+++ b/controllers/vhost_controller_test.go
@@ -116,10 +116,6 @@ var _ = Describe("vhost-controller", func() {
 	})
 
 	Context("creation", func() {
-		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, &vhost)).To(Succeed())
-		})
-
 		When("the RabbitMQ Client returns a HTTP error response", func() {
 			BeforeEach(func() {
 				vhostName = "test-http-error"
@@ -187,6 +183,11 @@ var _ = Describe("vhost-controller", func() {
 
 		Context("vhost limits", func() {
 			var connections, queues int32
+
+			AfterEach(func() {
+				// Must reset the vhost limits to avoid test pollution
+				vhostLimits = nil
+			})
 
 			When("vhost limits are provided", func() {
 				BeforeEach(func() {


### PR DESCRIPTION

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- **Fix deletion policy tests**
- **Use go run for ginkgo CLI**
- **Refactor controller tests**
- **Fix vhost controller test flakes**

## Additional Context

The "retain" tests were had a flaky behaviour. Sometimes they were passing due to a flake. The "retain" tests were
creating and deleting their topology objects one call right after
the other, without asserting that the object was created (from etcd PoV). When the object deletion logic started
"too soon", before etcd recorded the object creation, the tests were passing because the controller has a logic
to skip deletion if the object is not found. They were also very sensible to test pollution (which was already
present, it was not introduced by the "retain" contribution). Other controllers could overwrite the retain policy
to its default `delete`, causing the "retain" tests to rightfuly fail.

To fix the test pollution, the refactor changed the manager setup, to use label selectors for the controller
informer cache. In addition to the existing namespace filtering. Due to this change, the manager has to start
later in the test setup, because the tests use the topology object name as label, and this value is not known
to the setup logic until its very close to the test.

Finally, the last remain of test pollution was in the vhost "limits" test. These tests left behind a variable
that is always used in the vhost object initialisation. When the "limits" tests ran before the "delete" tests,
these would cause a flake. This did not always happen because we (correctly) randomise the test execution order
with ginkgo.
