### PR TITLE
Fix logging key error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ K8S_OPERATOR_NAMESPACE ?= rabbitmq-system
 .PHONY: docker-registry-secret
 docker-registry-secret:
 	$(call check_defined, DOCKER_REGISTRY_USERNAME, Username for accessing the docker registry)
-	$(call check_defined, DOCKER_REGISTRY_PASSWORD. Password for accessing the docker registry)
+	$(call check_defined, DOCKER_REGISTRY_PASSWORD, Password for accessing the docker registry)
 	$(call check_defined, DOCKER_REGISTRY_SECRET, Name of Kubernetes secret in which to store the Docker registry username and password)
 	$(call check_defined, DOCKER_REGISTRY_SERVER, URL of docker registry containing the Operator image (e.g. registry.my-company.com))
 	@echo "Creating registry secret and patching default service account"
@@ -235,7 +235,7 @@ destroy: ## Delete all resources of this Operator
 .PHONY: deploy-dev
 deploy-dev: cmctl docker-build-dev manifests deploy-rbac docker-registry-secret ## Build current code as a Docker image, push the image, and deploy to current Kubernetes context
 	$(call check_defined, DOCKER_REGISTRY_USERNAME, Username for accessing the docker registry)
-	$(call check_defined, DOCKER_REGISTRY_PASSWORD. Password for accessing the docker registry)
+	$(call check_defined, DOCKER_REGISTRY_PASSWORD, Password for accessing the docker registry)
 	$(call check_defined, DOCKER_REGISTRY_SECRET, Name of Kubernetes secret in which to store the Docker registry username and password)
 	$(call check_defined, DOCKER_REGISTRY_SERVER, URL of docker registry containing the Operator image (e.g. registry.my-company.com))
 	$(CMCTL) check api --wait=2m

--- a/controllers/vhost_controller.go
+++ b/controllers/vhost_controller.go
@@ -25,14 +25,14 @@ func (r *VhostReconciler) DeclareFunc(ctx context.Context, client rabbitmqclient
 	logger := ctrl.LoggerFrom(ctx)
 	vhost := obj.(*topology.Vhost)
 	settings := internal.GenerateVhostSettings(vhost)
-	logger.Info("generated vhost settings", "vhost", vhost.Spec.Name, "settings", settings)
+	logger.V(1).Info("generated vhost settings", "vhost", vhost.Spec.Name, "settings", settings)
 	err := validateResponse(client.PutVhost(vhost.Spec.Name, *settings))
 	if err != nil {
 		return err
 	}
 
 	newVhostLimits := internal.GenerateVhostLimits(vhost.Spec.VhostLimits)
-	logger.Info("getting existing vhost limits", vhost, vhost.Spec.Name)
+	logger.V(1).Info("getting existing vhost limits", "vhost", vhost.Spec.Name)
 	existingVhostLimits, err := r.getVhostLimits(client, vhost.Spec.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION

This closes #990

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

The keys of the key-value fields for logger must be string type. We were passing the entire vhost object.

