### PR TITLE
Recover integration test for owner reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ export KUBEBUILDER_ASSETS = $(LOCAL_TESTBIN)/k8s/$(ENVTEST_K8S_VERSION)-$(platfo
 
 .PHONY: kubebuilder-assets
 kubebuilder-assets: $(KUBEBUILDER_ASSETS)
-	@echo "export KUBEBUILDER_ASSETS = $(LOCAL_TESTBIN)/k8s/$(ENVTEST_K8S_VERSION)-$(platform)-$(ARCHITECTURE)"
+	@echo "export KUBEBUILDER_ASSETS=$(LOCAL_TESTBIN)/k8s/$(ENVTEST_K8S_VERSION)-$(platform)-$(ARCHITECTURE)"
 
 $(KUBEBUILDER_ASSETS):
 	setup-envtest --os $(platform) --arch $(ARCHITECTURE) --bin-dir $(LOCAL_TESTBIN) use $(ENVTEST_K8S_VERSION)

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -97,7 +97,9 @@ func (r *UserReconciler) declareCredentials(ctx context.Context, user *topology.
 			// https://github.com/rabbitmq/cluster-operator/blob/057b61eb50102a66f504b31464e5956526cbdc90/internal/resource/statefulset.go#L220-L226
 			// https://github.com/rabbitmq/messaging-topology-operator/issues/194
 			for i := range credentialSecret.ObjectMeta.OwnerReferences {
-				credentialSecret.ObjectMeta.OwnerReferences[i].BlockOwnerDeletion = ptr.To(false)
+				if credentialSecret.ObjectMeta.OwnerReferences[i].Kind == user.Kind {
+					credentialSecret.ObjectMeta.OwnerReferences[i].BlockOwnerDeletion = ptr.To(false)
+				}
 			}
 			return nil
 		})

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -199,6 +199,11 @@ var _ = Describe("UserController", func() {
 		})
 
 		Context("user limits", func() {
+			AfterEach(func() {
+				userLimits.Connections = nil
+				userLimits.Channels = nil
+			})
+
 			When("the user has limits defined", func() {
 				BeforeEach(func() {
 					userName = "test-user-limits"


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

- **Recover owner reference test for User**
- **Tweak kubebuilder-assets target**

As part of abc57371b359bf099fc89052a47db7e828258c58, we chopped the test related to owner references. The system tests verify that objects are garbage collected, and that proves that an owner reference is set. However, the system tests do not explicitly verify that the object does not block the owner deletion. This is required for OpenShift compatibility.

This PR recovers the owner reference test for User generated secret.