### PR TITLE
RMQ-1956, RMQ-1961 : Fix CVEs 2025-4674 and 2025-4674

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rabbitmq/messaging-topology-operator
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/cloudflare/cfssl v1.6.5

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,8 +1,6 @@
 module tools
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.24.6
 
 require (
 	github.com/elastic/crd-ref-docs v0.1.0


### PR DESCRIPTION
This closes #
https://vmw-jira.broadcom.net/browse/RMQ-1961
https://vmw-jira.broadcom.net/browse/RMQ-1956

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes
Bump go to fix CVEs : [CVE-2025-4674](https://www.cve.org/CVERecord?id=CVE-2025-4674) and [CVE-2025-47907](https://www.cve.org/CVERecord?id=CVE-2025-47907)

