### PR TITLE
Create tool group for dependabot tool updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     interval: "daily"
 - package-ecosystem: "gomod"
   directory: "/internal/tools/"
+  groups:
+    tools:
+      patterns:
+      - '*'
   schedule:
     interval: "daily"
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot can group PRs together to reduce the sheer number of PRs. This also helps by avoiding merge conflicts and rebasing.
