### PR TITLE
Use GHCR to publish container image

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -63,6 +63,7 @@ jobs:
     permissions:
       contents: 'write'
       id-token: 'write'
+      packages: 'write'
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
     steps:
@@ -70,9 +71,11 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Install Go
+      id: set-go
       uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
+        check-latest: true
 
     - name: OCI Metadata
       id: meta
@@ -81,6 +84,7 @@ jobs:
         images: |
           rabbitmqoperator/messaging-topology-operator
           quay.io/rabbitmqoperator/messaging-topology-operator
+          ghcr.io/rabbitmq/messaging-topology-operator
         # generate Docker tags based on the following events/attributes
         tags: |
           type=sha
@@ -93,22 +97,30 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to Quay.io
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
       uses: docker/login-action@v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
+    - name: Login to GHCR
+      if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
       uses: docker/build-push-action@v6
       with:
         context: .
@@ -117,6 +129,8 @@ jobs:
         provenance: false
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          GO_TAG=${{ steps.set-go.outputs.go-version }}
 
     - name: Build to TAR
       id: build_tar
@@ -128,6 +142,8 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         outputs: |
           type=docker,dest=./operator.tar
+        build-args: |
+          GO_TAG=${{ steps.set-go.outputs.go-version }}
 
     - name: Upload Operator artifact
       uses: actions/upload-artifact@v5
@@ -149,7 +165,7 @@ jobs:
         kustomize edit set image \
         rabbitmqoperator/messaging-topology-operator-dev=rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
         popd
-        make generate-manifests QUAY_IO_OPERATOR_IMAGE=quay.io/rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
+        make generate-manifests QUAY_IO_OPERATOR_IMAGE=quay.io/rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}" GHCR_IO_OPERATOR_IMAGE=ghcr.io/rabbitmq/messaging-topology-operator:"${RELEASE_VERSION}"
 
     - name: Upload operator manifests
       uses: actions/upload-artifact@v5
@@ -174,6 +190,10 @@ jobs:
       contents: 'write'
       id-token: 'write'
     needs: build_operator
+    env:
+      # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0
+      # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
+      KIND_NODE_IMAGE: "kindest/node:v1.32.0"
     steps:
     - name: Check out code
       uses: actions/checkout@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+ARG GO_TAG=1.24
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_TAG} AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ api-reference: install-tools
 		--max-depth 30
 
 QUAY_IO_OPERATOR_IMAGE ?= quay.io/rabbitmqoperator/messaging-topology-operator:latest
+GHCR_IO_OPERATOR_IMAGE ?= ghcr.io/rabbitmq/messaging-topology-operator:latest
 ## used in CI pipeline to create release artifact
 .PHONY: generate-manifests
 generate-manifests: | $(YTT)
@@ -166,8 +167,10 @@ generate-manifests: | $(YTT)
 	kustomize build config/installation/  > releases/messaging-topology-operator.bak
 	sed '/CERTIFICATE_NAMESPACE.*CERTIFICATE_NAME/d' releases/messaging-topology-operator.bak > releases/messaging-topology-operator.yaml
 	$(YTT) -f releases/messaging-topology-operator.yaml -f config/ytt_overlays/change_deployment_image.yml --data-value operator_image=$(QUAY_IO_OPERATOR_IMAGE) > releases/messaging-topology-operator-quay-io.yaml
+	$(YTT) -f releases/messaging-topology-operator.yaml -f config/ytt_overlays/change_deployment_image.yml --data-value operator_image=$(GHCR_IO_OPERATOR_IMAGE) > releases/messaging-topology-operator-ghcr-io.yaml
 	kustomize build config/installation/cert-manager/ > releases/messaging-topology-operator-with-certmanager.yaml
 	$(YTT) -f releases/messaging-topology-operator-with-certmanager.yaml -f config/ytt_overlays/change_deployment_image.yml --data-value operator_image=$(QUAY_IO_OPERATOR_IMAGE) > releases/messaging-topology-operator-with-certmanager-quay-io.yaml
+	$(YTT) -f releases/messaging-topology-operator-with-certmanager.yaml -f config/ytt_overlays/change_deployment_image.yml --data-value operator_image=$(GHCR_IO_OPERATOR_IMAGE) > releases/messaging-topology-operator-with-certmanager-ghcr-io.yaml
 
 # Run go fmt against code
 fmt:


### PR DESCRIPTION
**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

This commit introduces support for GitHub Container Registry (GHCR) in the
messaging-topology-operator's CI/CD pipeline. Previously, images were only
pushed to Docker Hub and Quay.io.

Key changes include:
* Updating the GitHub Actions workflow to log in to GHCR and push built images.
* Modifying the Makefile to define the GHCR image and generate Kubernetes
  manifests that reference the GHCR hosted images.

This enhancement allows for broader distribution and accessibility of the
operator images.

## Additional Context

The same was done for the cluster operator via rabbitmq/cluster-operator#1939

