### PR TITLE
Update drop capabilities to ALL

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - All
+            - ALL
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault


### PR DESCRIPTION
Because the Pod admission controller is case sensitive
