### PR TITLE
Fix security context: take 2 🎬

### DIFF
--- a/config/default/base/manager_webhook_patch.yaml
+++ b/config/default/base/manager_webhook_patch.yaml
@@ -16,14 +16,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - All
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
       volumes:
       - name: cert
         secret:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -16,14 +16,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - All
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
       volumes:
       - name: cert
         secret:


### PR DESCRIPTION
This closes #1073

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

In #1067 the capabilities was changed to caps, but some kustomize
patches were setting the securtity context. Those patches do not need to
set a security context, because they don't alter the context from the
"main" deploment manifest.

