### PR TITLE
Bump kind to latest image version.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -175,7 +175,7 @@ jobs:
     env:
       # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0
       # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
-      KIND_NODE_IMAGE: "kindest/node:v1.32.0"
+      KIND_NODE_IMAGE: "kindest/node:v1.34.0"
     steps:
     - name: Check out code
       uses: actions/checkout@v6


### PR DESCRIPTION
v0.30.0 of kind includes K8s pre-built images v1.34.0, v1.33.4, v1.32.8, and v1.31.12
