### PR TITLE
Bump golang and deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rabbitmq/messaging-topology-operator
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/cloudflare/cfssl v1.6.5

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/elastic/crd-ref-docs v0.2.0


### PR DESCRIPTION
This fixes https://pkg.go.dev/vuln/GO-2025-4155 ([CVE-2025-61729](https://nvd.nist.gov/vuln/detail/CVE-2025-61729)) reported by TVS.
