### PR TITLE
chore: add automated tool version update workflow

### DIFF
--- a/.github/workflows/update-tool-versions.yml
+++ b/.github/workflows/update-tool-versions.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Check for GitHub binary tool updates
         id: check-github-tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           UPDATES_FILE="updates.txt"
 
@@ -148,7 +150,7 @@ jobs:
           commit-message: "chore: update tool versions"
           title: "chore: update tool versions"
           body-path: pr_body.md
-          branch: automated-tool-updates-${{ github.run_number }}
+          branch: automated-tool-updates
           delete-branch: true
           labels: |
             dependencies

--- a/hack/README.md
+++ b/hack/README.md
@@ -96,8 +96,8 @@ cat updates.txt
 
 ## Requirements
 
-- **For Go tools:** Go must be installed and accessible
-- **For GitHub tools:** `curl` and `jq` must be installed
+- **For Go tools:** Go must be installed and accessible (no `jq` required)
+- **For GitHub tools:** `gh` CLI must be installed and authenticated
 - Both scripts require `grep`, `awk`, `sed` (standard on most Unix systems)
 
 ## Integration

--- a/hack/check-github-tool-versions.sh
+++ b/hack/check-github-tool-versions.sh
@@ -4,7 +4,7 @@
 # Usage: ./hack/check-github-tool-versions.sh <makefile-path> <updates-file>
 #
 # This script reads tool versions from the Makefile and checks for updates
-# using the GitHub Releases API. Results are appended to the updates file.
+# using the gh CLI. Results are appended to the updates file.
 
 set -euo pipefail
 
@@ -21,10 +21,10 @@ check_github_version() {
   
   echo "Checking $var_name (current: $current_version)..."
   
-  # Get latest release from GitHub API
-  latest=$(curl -s "https://api.github.com/repos/$repo/releases/latest" | jq -r '.tag_name')
+  # Get latest release tag using the gh CLI
+  latest=$(gh release view -R "$repo" --json tagName --template '{{ .tagName }}{{ "\n" }}' 2>/dev/null || echo "")
   
-  if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+  if [ -z "$latest" ]; then
     echo "  Warning: Could not fetch latest release for $repo"
     return
   fi

--- a/hack/check-go-tool-versions.sh
+++ b/hack/check-go-tool-versions.sh
@@ -18,11 +18,12 @@ check_go_version() {
   local var_name=$1
   local module=$2
   local current_version=$3
+  local repo_url=$4
   
   echo "Checking $var_name (current: $current_version)..."
   
   # Get all versions for the module
-  versions=$(go list -m -versions -json "$module" 2>/dev/null | jq -r '.Versions[]?' || echo "")
+  versions=$(go list -m -versions -f '{{range .Versions}}{{.}} {{end}}' "$module" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' || echo "")
   
   if [ -z "$versions" ]; then
     echo "  Warning: Could not fetch versions for $module"
@@ -43,7 +44,7 @@ check_go_version() {
   
   if [ "$current_clean" != "$latest_clean" ]; then
     echo "  ✓ Update available: $current_version → $latest"
-    echo "$var_name|$current_version|$latest|https://github.com/${module%%/*}/$(echo $module | cut -d'/' -f2-)" >> "$UPDATES_FILE"
+    echo "$var_name|$current_version|$latest|$repo_url" >> "$UPDATES_FILE"
   else
     echo "  Already up-to-date"
   fi
@@ -60,13 +61,13 @@ YJ_VERSION=$(grep '^YJ_VERSION' "$MAKEFILE" | awk -F'= ' '{print $2}')
 GOVULNCHECK_VERSION=$(grep '^GOVULNCHECK_VERSION' "$MAKEFILE" | awk -F'= ' '{print $2}')
 
 # Check each Go tool
-check_go_version "KUSTOMIZE_VERSION" "sigs.k8s.io/kustomize/kustomize/v5" "$KUSTOMIZE_VERSION"
-check_go_version "CONTROLLER_TOOLS_VERSION" "sigs.k8s.io/controller-tools/cmd/controller-gen" "$CONTROLLER_TOOLS_VERSION"
-check_go_version "GOLANGCI_LINT_VERSION" "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" "$GOLANGCI_LINT_VERSION"
-check_go_version "CRD_REF_DOCS_VERSION" "github.com/elastic/crd-ref-docs" "$CRD_REF_DOCS_VERSION"
-check_go_version "COUNTERFEITER_VERSION" "github.com/maxbrunsfeld/counterfeiter/v6" "$COUNTERFEITER_VERSION"
-check_go_version "GINKGO_VERSION" "github.com/onsi/ginkgo/v2/ginkgo" "$GINKGO_VERSION"
-check_go_version "YJ_VERSION" "github.com/sclevine/yj/v5" "$YJ_VERSION"
-check_go_version "GOVULNCHECK_VERSION" "golang.org/x/vuln/cmd/govulncheck" "$GOVULNCHECK_VERSION"
+check_go_version "KUSTOMIZE_VERSION" "sigs.k8s.io/kustomize/kustomize/v5" "$KUSTOMIZE_VERSION" "https://github.com/kubernetes-sigs/kustomize"
+check_go_version "CONTROLLER_TOOLS_VERSION" "sigs.k8s.io/controller-tools" "$CONTROLLER_TOOLS_VERSION" "https://github.com/kubernetes-sigs/controller-tools"
+check_go_version "GOLANGCI_LINT_VERSION" "github.com/golangci/golangci-lint/v2" "$GOLANGCI_LINT_VERSION" "https://github.com/golangci/golangci-lint"
+check_go_version "CRD_REF_DOCS_VERSION" "github.com/elastic/crd-ref-docs" "$CRD_REF_DOCS_VERSION" "https://github.com/elastic/crd-ref-docs"
+check_go_version "COUNTERFEITER_VERSION" "github.com/maxbrunsfeld/counterfeiter/v6" "$COUNTERFEITER_VERSION" "https://github.com/maxbrunsfeld/counterfeiter"
+check_go_version "GINKGO_VERSION" "github.com/onsi/ginkgo/v2" "$GINKGO_VERSION" "https://github.com/onsi/ginkgo"
+check_go_version "YJ_VERSION" "github.com/sclevine/yj/v5" "$YJ_VERSION" "https://github.com/sclevine/yj"
+check_go_version "GOVULNCHECK_VERSION" "golang.org/x/vuln" "$GOVULNCHECK_VERSION" "https://github.com/golang/vuln"
 
 echo "Go tools check complete"


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that automatically checks for new versions of development tools and creates pull requests when updates are available.

## Changes

- ✨ **New workflow**: `.github/workflows/update-tool-versions.yml`
  - Runs daily at 00:00 UTC
  - Manual trigger with dry-run option
  - Rich GitHub Step Summary output
  - Single PR strategy for all updates

- 🔧 **Version check scripts**: `hack/check-go-tool-versions.sh` and `hack/check-github-tool-versions.sh`
  - Standalone scripts for local verification
  - Check Go-installable tools via `go list -m -versions`
  - Check GitHub binary tools via Releases API

- 📚 **Documentation**: 
  - `hack/README.md` - Script usage and local testing

## Monitored Tools

### Go-installable tools (8)
- kustomize, controller-gen, golangci-lint, crd-ref-docs, counterfeiter, ginkgo, yj, govulncheck

### GitHub binary tools (3)
- kind, ytt, cmctl

### Excluded from automation
- OPENAPI_GEN (tracks `master` branch)
- ENVTEST_VERSION (derived from go.mod)
- ENVTEST_K8S_VERSION (derived from go.mod)
- CERT_MANAGER_VERSION (installation-only)

## Testing

The scripts can be tested locally:

```bash
# Check for updates
./hack/check-go-tool-versions.sh
./hack/check-github-tool-versions.sh

# View results
cat updates.txt
```

The workflow can be tested via the Actions UI with dry-run mode enabled.

## Benefits

1. **Automated maintenance**: No manual version checking required
2. **Local verification**: Scripts can be run locally before workflow execution
3. **Rich feedback**: GitHub Step Summary provides instant visual feedback
4. **Dependabot alternative**: Handles Makefile tools that Dependabot cannot
5. **Single PR strategy**: Reduces review overhead

---

🤖 Ready to automate tool version management!

Made with [Cursor](https://cursor.com)