### PR TITLE
Explicitly add Makefile in update-tools

### DIFF
--- a/.github/workflows/update-tool-versions.yml
+++ b/.github/workflows/update-tool-versions.yml
@@ -155,6 +155,7 @@ jobs:
           labels: |
             dependencies
             automation
+          add-paths: Makefile
 
       - name: Dry run summary
         if: github.event.inputs.dry_run == 'true' && steps.check-updates.outputs.updates_available == 'true'


### PR DESCRIPTION
Because otherwise it adds the pr body and updates text files. Those files are intermediate files created to generate the PR.