### PR TITLE
Fix events permission

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,14 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - get
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -29,6 +21,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - rabbitmq.com
   resources:

--- a/internal/controller/queue_controller.go
+++ b/internal/controller/queue_controller.go
@@ -26,7 +26,6 @@ import (
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;create;patch
 
 type QueueReconciler struct{}
 

--- a/internal/controller/super_stream_controller.go
+++ b/internal/controller/super_stream_controller.go
@@ -53,7 +53,6 @@ type SuperStreamReconciler struct {
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;create;patch
 
 func (r *SuperStreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)

--- a/internal/controller/topology_controller.go
+++ b/internal/controller/topology_controller.go
@@ -39,6 +39,9 @@ type TopologyReconciler struct {
 	MaxConcurrentReconciles int
 }
 
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+
+// Reconcile is the main entry point for the TopologyReconciler
 func (r *TopologyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	obj := r.Type.DeepCopyObject().(topology.TopologyResource)


### PR DESCRIPTION
Because we changed the function, which changed the API, which required new RBAC. Of course, pkg.go.dev did not warn about that. Found the answer in Kubebuilder book.
