### PR TITLE
Fix queue properties for queues used in system tests.

### DIFF
--- a/test/system/binding_system_test.go
+++ b/test/system/binding_system_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Binding", func() {
 				RabbitmqClusterReference: topology.RabbitmqClusterReference{
 					Name: rmq.Name,
 				},
+				AutoDelete: false,
+				Durable:    true,
 			},
 		}
 		Expect(k8sClient.Create(ctx, queue, &client.CreateOptions{})).To(Succeed())

--- a/test/system/rabbitmq_connection_test.go
+++ b/test/system/rabbitmq_connection_test.go
@@ -56,13 +56,15 @@ var _ = Describe("RabbitMQ connection using provided connection secret", func() 
 				RabbitmqClusterReference: topology.RabbitmqClusterReference{
 					ConnectionSecret: &corev1.LocalObjectReference{Name: secret.Name},
 				},
+				AutoDelete: false,
+				Durable:    true,
 			},
 		}
 		Expect(k8sClient.Create(ctx, q, &client.CreateOptions{})).To(Succeed())
 		var qInfo *rabbithole.DetailedQueueInfo
 		Eventually(func() error {
 			var err error
-			qInfo, err = rabbitClient.GetQueue("/", q.Name)
+			qInfo, err = rabbitClient.GetQueue(q.Spec.Vhost, q.Name)
 			return err
 		}, 20, 2).Should(Succeed())
 


### PR DESCRIPTION
Queues in some system tests were relying on default properties which are no longer allowed by RabbitMQ.