### PR TITLE
Fix OLM package generation

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -262,8 +262,9 @@ jobs:
             git checkout rabbitmq-messaging-topology-operator-$BUNDLE_VERSION
 
             mkdir -pv operators/rabbitmq-messaging-topology-operator/
-            rm -v -f olm-package-ci/bundle.Dockerfile
+            rm -v -f olm-package-ci/bundle/bundle.Dockerfile
             cp -v -fR olm-package-ci/bundle ./operators/rabbitmq-messaging-topology-operator/"$BUNDLE_VERSION"
+            cp -v olm-package-ci/release-config.yaml ./operators/rabbitmq-messaging-topology-operator/"$BUNDLE_VERSION"/
             git add operators/rabbitmq-messaging-topology-operator
             git commit -s -m "RabbitMQ Topology Operator release $BUNDLE_VERSION"
             git push --set-upstream origin "rabbitmq-messaging-topology-operator-$BUNDLE_VERSION"


### PR DESCRIPTION
Red Hat Marketplace format is different because we use FBC. The release config file, which automates updating the catalog in the marketplace, was not included. Additionally, the folder layout was not as intended. This commit fixes both issues.

Found this issue in this PR: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9672