### PR TITLE
Fix User deletion logic

### DIFF
--- a/internal/controller/permission_controller.go
+++ b/internal/controller/permission_controller.go
@@ -72,9 +72,8 @@ func getUsernameFromUser(ctx context.Context, k8sClient client.Client, namespace
 
 	// get username from User status
 	if user.Status.Username == "" {
-		err := fmt.Errorf("this User does not have an username set in its status")
-		logger.Error(err, failureMsg, "userReference", name)
-		return nil, err
+		logger.Info("this User does not have a username set in its status", "userReference", name)
+		return user, nil
 	}
 	return user, nil
 }

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -289,6 +289,11 @@ func (r *UserReconciler) DeleteFunc(ctx context.Context, rmqc rabbitmqclient.Cli
 	logger := ctrl.LoggerFrom(ctx)
 	user := obj.(*topology.User)
 
+	if user.Status.Username == "" {
+		logger.Info("user never successfully created in rabbitmq server; skipping deletion", "user", user.Name)
+		return nil
+	}
+
 	err := validateResponseForDeletion(rmqc.DeleteUser(user.Status.Username))
 	if errors.Is(err, ErrNotFound) {
 		logger.Info("cannot find user in rabbitmq server; already deleted", "user", user.Name)

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -439,6 +439,45 @@ var _ = Describe("UserController", func() {
 		})
 	})
 
+	When("deleting a user that was never successfully created", func() {
+		BeforeEach(func() {
+			userName = "delete-user-never-created"
+			initialiseUser()
+			user.Spec.ImportCredentialsSecret = &corev1.LocalObjectReference{
+				Name: "does-not-exist",
+			}
+			user.Labels = map[string]string{"test": userName}
+			initialiseManager("test", userName)
+		})
+
+		It("successfully deletes the user", func() {
+			Expect(k8sClient.Create(ctx, &user)).To(Succeed())
+
+			// Wait for the user to be created and have a finalizer
+			Eventually(func() []string {
+				_ = k8sClient.Get(
+					ctx,
+					types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
+					&user,
+				)
+				return user.Finalizers
+			}).
+				Within(statusEventsUpdateTimeout).
+				WithPolling(time.Second).
+				Should(ContainElement("deletion.finalizers.users.rabbitmq.com"))
+
+			Expect(k8sClient.Delete(ctx, &user)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &topology.User{})
+				return apierrors.IsNotFound(err)
+			}).
+				Within(statusEventsUpdateTimeout).
+				WithPolling(time.Second).
+				Should(BeTrue())
+		})
+	})
+
 	It("sets an owner reference and does not block owner deletion", func() {
 		userName = "test-owner-reference"
 		initialiseUser()


### PR DESCRIPTION

This closes #1171

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Fix user deletion logic.

## Additional Context

When a User resource fails to be created in RabbitMQ (e.g., due to missing
credentials secret), its status.username remains empty. Previously, attempting
to delete such a resource would try to delete a user with an empty username
from RabbitMQ, or get stuck in reconciliation.

This change adds a check in the user deletion handler to skip the RabbitMQ
deletion call when status.username is empty, allowing the Kubernetes resource
to be cleaned up properly. It also updates the permission controller to handle
references to users that don't yet have a username set, returning the user
object instead of an error to allow graceful handling downstream.

Includes test coverage for deleting a user that was never successfully created.
