### PR TITLE
Bump k8s versions in Actions

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -167,9 +167,9 @@ jobs:
       contents: 'write'
     needs: build_operator
     env:
-      # Taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0
-      # The image here should be listed under 'Images built for this release' for the version of kind in go.mod
-      KIND_NODE_IMAGE: "kindest/node:v1.32.0"
+      # Taken from https://hub.docker.com/r/kindest/node/tags
+      # We should update this to match the maximum version of k8s supported by VKS and/or OCP
+      KIND_NODE_IMAGE: "kindest/node:v1.35.1"
     steps:
     - name: Check out code
       uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,8 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
-        k8s: [v1.26.6, v1.30.4, v1.33.7]
+        k8s: [v1.31.14, v1.32.8, v1.33.7, v1.34.3]
     steps:
     - name: Check out code
       uses: actions/checkout@v6


### PR DESCRIPTION
Bumping to newer supported k8s versions. As of this writing, VKS supports 1.29 - 1.35. Openshift supports 1.31 - 1.34. VKS with 1.29 - 1.30 should be mostly supervisor clusters.

This PR also adds `fail-fast: false` to matrix testing strategy, because the failure of system tests in one specific k8s version does not imply failure in other k8s versions.