### PR TITLE
fix: installation kustomize to refer new ghcr image

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -140,7 +140,7 @@ jobs:
         make install-tools
         pushd config/installation
         kustomize edit set image \
-        localhost/messaging-topology-operator=rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
+        rabbitmqoperator/messaging-topology-operator=rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}"
         popd
         make generate-manifests QUAY_IO_OPERATOR_IMAGE=quay.io/rabbitmqoperator/messaging-topology-operator:"${RELEASE_VERSION}" GHCR_IO_OPERATOR_IMAGE=ghcr.io/rabbitmq/messaging-topology-operator:"${RELEASE_VERSION}"
 

--- a/config/installation/kustomization.yaml
+++ b/config/installation/kustomization.yaml
@@ -10,8 +10,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rabbitmq-system
 images:
-- name: rabbitmqoperator/messaging-topology-operator-dev
-  newName: rabbitmqoperator/messaging-topology-operator
+- name: localhost/messaging-topology-operator
+  newName: ghcr.io/rabbitmq/messaging-topology-operator
   newTag: latest
 
 resources:

--- a/config/installation/kustomization.yaml
+++ b/config/installation/kustomization.yaml
@@ -10,7 +10,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rabbitmq-system
 images:
-- name: localhost/messaging-topology-operator
+- name: rabbitmqoperator/messaging-topology-operator
   newName: ghcr.io/rabbitmq/messaging-topology-operator
   newTag: latest
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: localhost/messaging-topology-operator
-  newTag: v0.0.1
+  newName: rabbitmqoperator/messaging-topology-operator
+  newTag: latest


### PR DESCRIPTION
This closes - no issue created yet

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

Hello, trying to install this operator using argo+kustomize and running into interesting problem.
After the 1.19.0 release this kustomize installation yaml is doing basically a no-op, trying to image+tag by key  that doesnt exist. 

This results into the kustomize falling back to some localhost image.. which I would guess is not correct looking at [sibling cluster operator](https://github.com/rabbitmq/cluster-operator/blob/main/config/installation/kustomization.yaml)

```
❯ kustomize build config/installation | grep 'image:'

        image: localhost/messaging-topology-operator:v0.0.1
```

Providing patch to fix it by replacing it to the correct ghcr image.

## Additional Context
