### PR TITLE
Handle permission deletion while cluster deletion in progress.

### DIFF
--- a/internal/controller/permission_controller_test.go
+++ b/internal/controller/permission_controller_test.go
@@ -548,7 +548,7 @@ var _ = Describe("permission-controller", func() {
 			EventuallyWithOffset(1, func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &corev1.Secret{})
 				return apierrors.IsNotFound(err)
-			}, statusEventsUpdateTimeout).Should(BeTrue())
+			}, statusEventsUpdateTimeout).Should(BeTrue(), "Secret should not be found")
 
 			By("deleting the permission")
 			Expect(k8sClient.Delete(ctx, &permission)).To(Succeed())

--- a/internal/controller/permission_controller_test.go
+++ b/internal/controller/permission_controller_test.go
@@ -487,20 +487,79 @@ var _ = Describe("permission-controller", func() {
 				Expect(k8sClient.Delete(ctx, &user)).To(Succeed())
 			})
 
-			It("sets the correct deletion ownerref to the object", func() {
-				Expect(k8sClient.Create(ctx, &user)).To(Succeed())
-				user.Status.Username = userName
-				Expect(k8sClient.Status().Update(ctx, &user)).To(Succeed())
-				Expect(k8sClient.Create(ctx, &permission)).To(Succeed())
-				Eventually(func() []metav1.OwnerReference {
-					var fetched topology.Permission
-					err := k8sClient.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &fetched)
-					if err != nil {
-						return []metav1.OwnerReference{}
-					}
-					return fetched.ObjectMeta.OwnerReferences
-				}, 5).Should(Not(BeEmpty()))
-			})
+		})
+	})
+
+	When("the RabbitmqCluster default-user secret is removed during deletion", func() {
+		var cluster *v1beta1.RabbitmqCluster
+
+		BeforeEach(func() {
+			permissionName = "test-delete-cluster-secret-gone"
+			initialiseManager("test", permissionName)
+
+			cluster = &v1beta1.RabbitmqCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret-gone-rabbit",
+					Namespace: permissionNamespace,
+				},
+			}
+			Expect(createRabbitmqClusterResources(k8sClient, cluster)).To(Succeed())
+
+			permission = topology.Permission{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      permissionName,
+					Namespace: permissionNamespace,
+					Labels:    map[string]string{"test": permissionName},
+				},
+				Spec: topology.PermissionSpec{
+					RabbitmqClusterReference: topology.RabbitmqClusterReference{Name: "secret-gone-rabbit"},
+					User:                     "example",
+					Vhost:                    "example",
+				},
+			}
+			fakeRabbitMQClient.UpdatePermissionsInReturns(&http.Response{Status: "201 Created", StatusCode: http.StatusCreated}, nil)
+			fakeRabbitMQClient.ClearPermissionsInReturns(&http.Response{Status: "204 No Content", StatusCode: http.StatusNoContent}, nil)
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
+		})
+
+		It("removes the finalizer so the Permission can be deleted", func() {
+			Expect(k8sClient.Create(ctx, &permission)).To(Succeed())
+			EventuallyWithOffset(1, func() []topology.Condition {
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &permission)
+				return permission.Status.Conditions
+			}, statusEventsUpdateTimeout, 1*time.Second).Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})))
+
+			// Simulate cluster teardown: default-user secret removed while the cluster lingers.
+			By("deleting the default-user secret")
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-gone-rabbit-user-credentials",
+				Namespace: permissionNamespace,
+			}}
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			// Wait until the manager cache no longer serves the secret, so the delete
+			// reconcile deterministically hits the ParseReference not-found path.
+			EventuallyWithOffset(1, func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &corev1.Secret{})
+				return apierrors.IsNotFound(err)
+			}, statusEventsUpdateTimeout).Should(BeTrue())
+
+			By("deleting the permission")
+			Expect(k8sClient.Delete(ctx, &permission)).To(Succeed())
+			EventuallyWithOffset(1, func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &topology.Permission{})
+				return apierrors.IsNotFound(err)
+			}, statusEventsUpdateTimeout).Should(BeTrue())
+
+			observed := observedEvents()
+			Expect(observed).NotTo(ContainElement("Warning FailedDelete failed to delete permission"))
+			Expect(observed).To(ContainElement(ContainSubstring("Normal SuccessfulDelete successfully deleted")))
 		})
 	})
 })

--- a/internal/controller/permission_controller_test.go
+++ b/internal/controller/permission_controller_test.go
@@ -555,7 +555,7 @@ var _ = Describe("permission-controller", func() {
 			EventuallyWithOffset(1, func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: permission.Name, Namespace: permission.Namespace}, &topology.Permission{})
 				return apierrors.IsNotFound(err)
-			}, statusEventsUpdateTimeout).Should(BeTrue())
+			}, statusEventsUpdateTimeout).Should(BeTrue(), "Permission should be deleted already")
 
 			observed := observedEvents()
 			Expect(observed).NotTo(ContainElement("Warning FailedDelete failed to delete permission"))

--- a/rabbitmqclient/cluster_reference.go
+++ b/rabbitmqclient/cluster_reference.go
@@ -11,6 +11,7 @@ import (
 	topology "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
 	"gopkg.in/ini.v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -86,6 +87,9 @@ func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqC
 
 		secret := &corev1.Secret{}
 		if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cluster.Status.Binding.Name}, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, false, fmt.Errorf("failed to get default-user secret from reference: %s Error: %w", err, ErrNoSuchRabbitmqCluster)
+			}
 			return nil, false, err
 		}
 		var err error
@@ -109,6 +113,9 @@ func ParseReference(ctx context.Context, c client.Client, rmq topology.RabbitmqC
 
 	svc := &corev1.Service{}
 	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cluster.Status.DefaultUser.ServiceReference.Name}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, fmt.Errorf("failed to get service from reference: %s Error: %w", err, ErrNoSuchRabbitmqCluster)
+		}
 		return nil, false, err
 	}
 

--- a/rabbitmqclient/cluster_reference_test.go
+++ b/rabbitmqclient/cluster_reference_test.go
@@ -2,6 +2,7 @@ package rabbitmqclient_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/rabbitmq/messaging-topology-operator/rabbitmqclient"
@@ -118,6 +119,32 @@ var _ = Describe("ParseReference", func() {
 			It("errors", func() {
 				_, _, err := rabbitmqclient.ParseReference(ctx, fakeClient, topology.RabbitmqClusterReference{Name: existingRabbitMQCluster.Name}, existingRabbitMQCluster.Namespace, "", false)
 				Expect(err).To(MatchError(rabbitmqclient.ErrNoServiceReferenceSet))
+			})
+		})
+
+		When("default-user credentials Secret is absent", func() {
+			BeforeEach(func() {
+				// Include cluster and service but omit the binding secret
+				objs = []runtime.Object{existingRabbitMQCluster, existingService}
+			})
+
+			It("returns ErrNoSuchRabbitmqCluster", func() {
+				_, _, err := rabbitmqclient.ParseReference(ctx, fakeClient, topology.RabbitmqClusterReference{Name: existingRabbitMQCluster.Name}, existingRabbitMQCluster.Namespace, "", false)
+				Expect(err).To(MatchError(ContainSubstring(rabbitmqclient.ErrNoSuchRabbitmqCluster.Error())))
+				Expect(errors.Is(err, rabbitmqclient.ErrNoSuchRabbitmqCluster)).To(BeTrue())
+			})
+		})
+
+		When("RabbitMQ cluster service is absent", func() {
+			BeforeEach(func() {
+				// Include cluster and secret but omit the service
+				objs = []runtime.Object{existingRabbitMQCluster, existingCredentialSecret}
+			})
+
+			It("returns ErrNoSuchRabbitmqCluster", func() {
+				_, _, err := rabbitmqclient.ParseReference(ctx, fakeClient, topology.RabbitmqClusterReference{Name: existingRabbitMQCluster.Name}, existingRabbitMQCluster.Namespace, "", false)
+				Expect(err).To(MatchError(ContainSubstring(rabbitmqclient.ErrNoSuchRabbitmqCluster.Error())))
+				Expect(errors.Is(err, rabbitmqclient.ErrNoSuchRabbitmqCluster)).To(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
Ensure that if a cluster deletion is in progress, resulting in a missing default-user secret or service, that permission deletion is able to proceed.

This closes #1183

[ai-assisted=yes]
