### PR TITLE
RMQ-2841: Implement idempotent password update logic for User

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -6,6 +6,7 @@ import (
 )
 
 const ready ConditionType = "Ready"
+const passwordSynced ConditionType = "PasswordSynced"
 
 type ConditionType string
 
@@ -24,7 +25,7 @@ type Condition struct {
 
 // Ready indicates that the last Create/Update operator on the CR was successful.
 func Ready(lastConditions []Condition) Condition {
-	time := lastTransitionTime(corev1.ConditionTrue, lastConditions)
+	time := lastTransitionTime(ready, corev1.ConditionTrue, lastConditions)
 	return Condition{
 		Type:               ready,
 		Status:             corev1.ConditionTrue,
@@ -35,7 +36,7 @@ func Ready(lastConditions []Condition) Condition {
 
 // NotReady indicates that the last Create/Update operator on the CR failed.
 func NotReady(msg string, lastConditions []Condition) Condition {
-	time := lastTransitionTime(corev1.ConditionFalse, lastConditions)
+	time := lastTransitionTime(ready, corev1.ConditionFalse, lastConditions)
 	return Condition{
 		Type:               ready,
 		Status:             corev1.ConditionFalse,
@@ -45,11 +46,46 @@ func NotReady(msg string, lastConditions []Condition) Condition {
 	}
 }
 
-func lastTransitionTime(newStatus corev1.ConditionStatus, lastConditions []Condition) metav1.Time {
+// PasswordSynced indicates that the User's password was successfully synced to RabbitMQ.
+func PasswordSynced(lastConditions []Condition) Condition {
+	time := lastTransitionTime(passwordSynced, corev1.ConditionTrue, lastConditions)
+	return Condition{
+		Type:               passwordSynced,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: time,
+		Reason:             "SuccessfulPasswordSync",
+	}
+}
+
+// PasswordNotSynced indicates that the User's password failed to sync to RabbitMQ.
+func PasswordNotSynced(msg string, lastConditions []Condition) Condition {
+	time := lastTransitionTime(passwordSynced, corev1.ConditionFalse, lastConditions)
+	return Condition{
+		Type:               passwordSynced,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: time,
+		Reason:             "FailedPasswordSync",
+		Message:            msg,
+	}
+}
+
+func lastTransitionTime(conditionType ConditionType, newStatus corev1.ConditionStatus, lastConditions []Condition) metav1.Time {
 	for _, lastCondition := range lastConditions {
-		if lastCondition.Type == ready && lastCondition.Status == newStatus {
+		if lastCondition.Type == conditionType && lastCondition.Status == newStatus {
 			return lastCondition.LastTransitionTime
 		}
 	}
 	return metav1.Now()
+}
+
+// upsertCondition replaces the condition in conditions whose Type matches newCondition's Type,
+// or appends it if no such condition exists. Other condition types are left untouched.
+func upsertCondition(conditions []Condition, newCondition Condition) []Condition {
+	for i, c := range conditions {
+		if c.Type == newCondition.Type {
+			conditions[i] = newCondition
+			return conditions
+		}
+	}
+	return append(conditions, newCondition)
 }

--- a/api/v1beta1/user_types.go
+++ b/api/v1beta1/user_types.go
@@ -35,7 +35,8 @@ type UserSpec struct {
 	//    will be created. For more information, see https://www.rabbitmq.com/docs/passwords.
 	//  * `password` – Plain-text password. Will be used only if the `passwordHash` key is missing.
 	//
-	// Note that this import only occurs at creation time, and is ignored once a password has been set on a User.
+	// The Operator watches this Secret and re-syncs the User's credentials to RabbitMQ whenever it changes,
+	// so updating the Secret's `password`/`passwordHash` rotates the User's password.
 	ImportCredentialsSecret *corev1.LocalObjectReference `json:"importCredentialsSecret,omitempty"`
 	// Limits to apply to a user to restrict the number of connections and channels
 	// the user can create. These limits can be used as guard rails in environments
@@ -54,6 +55,9 @@ type UserStatus struct {
 	Credentials *corev1.LocalObjectReference `json:"credentials,omitempty"`
 	// Provide rabbitmq Username
 	Username string `json:"username"`
+	// ObservedSecretVersion is the resourceVersion of the credentials Secret (generated or imported) that was
+	// last successfully applied to RabbitMQ. Used to avoid unnecessary password updates when nothing has changed.
+	ObservedSecretVersion string `json:"observedSecretVersion,omitempty"`
 }
 
 // UserTag defines the level of access to the management UI allocated to the user.
@@ -110,7 +114,9 @@ func (u *User) RabbitReference() RabbitmqClusterReference {
 }
 
 func (u *User) SetStatusConditions(c []Condition) {
-	u.Status.Conditions = c
+	for _, cond := range c {
+		u.Status.Conditions = upsertCondition(u.Status.Conditions, cond)
+	}
 }
 
 func init() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -350,7 +350,7 @@ func main() {
 		Recorder:                mgr.GetEventRecorder(controller.UserControllerName),
 		RabbitmqClientFactory:   rabbitmqclient.RabbitholeClientFactory,
 		KubernetesClusterDomain: clusterDomain,
-		ReconcileFunc:           &controller.UserReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()},
+		ReconcileFunc:           &controller.UserReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Recorder: mgr.GetEventRecorder(controller.UserControllerName)},
 		ConnectUsingPlainHTTP:   usePlainHTTP,
 		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {

--- a/config/crd/bases/rabbitmq.com_users.yaml
+++ b/config/crd/bases/rabbitmq.com_users.yaml
@@ -51,7 +51,8 @@ spec:
                      will be created. For more information, see https://www.rabbitmq.com/docs/passwords.
                    * `password` – Plain-text password. Will be used only if the `passwordHash` key is missing.
 
-                  Note that this import only occurs at creation time, and is ignored once a password has been set on a User.
+                  The Operator watches this Secret and re-syncs the User's credentials to RabbitMQ whenever it changes,
+                  so updating the Secret's `password`/`passwordHash` rotates the User's password.
                 properties:
                   name:
                     default: ""
@@ -185,6 +186,11 @@ spec:
                   User's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              observedSecretVersion:
+                description: |-
+                  ObservedSecretVersion is the resourceVersion of the credentials Secret (generated or imported) that was
+                  last successfully applied to RabbitMQ. Used to avoid unnecessary password updates when nothing has changed.
+                type: string
               username:
                 description: Provide rabbitmq Username
                 type: string

--- a/docs/api/rabbitmq.com.ref.asciidoc
+++ b/docs/api/rabbitmq.com.ref.asciidoc
@@ -1457,7 +1457,8 @@ password will be generated. The Secret must have the following keys in its Data 
    will be created. For more information, see https://www.rabbitmq.com/docs/passwords.
  * `password` – Plain-text password. Will be used only if the `passwordHash` key is missing.
 
-Note that this import only occurs at creation time, and is ignored once a password has been set on a User.
+The Operator watches this Secret and re-syncs the User's credentials to RabbitMQ whenever it changes,
+so updating the Secret's `password`/`passwordHash` rotates the User's password.
 | *`limits`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-userlimits[$$UserLimits$$]__ | Limits to apply to a user to restrict the number of connections and channels
 the user can create. These limits can be used as guard rails in environments
 where applications cannot be trusted and monitored in detail, for example,
@@ -1483,6 +1484,8 @@ User's generation, which is updated on mutation by the API Server.
 | *`conditions`* __xref:{anchor_prefix}-github-com-rabbitmq-messaging-topology-operator-api-v1beta1-condition[$$Condition$$] array__ | 
 | *`credentials`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Provides a reference to a Secret object containing the user credentials.
 | *`username`* __string__ | Provide rabbitmq Username
+| *`observedSecretVersion`* __string__ | ObservedSecretVersion is the resourceVersion of the credentials Secret (generated or imported) that was
+last successfully applied to RabbitMQ. Used to avoid unnecessary password updates when nothing has changed.
 |===
 
 

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	clientretry "k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
@@ -45,7 +46,8 @@ const (
 
 type UserReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder events.EventRecorder
 }
 
 func (r *UserReconciler) declareCredentials(ctx context.Context, user *topology.User) (string, error) {
@@ -141,7 +143,7 @@ func (r *UserReconciler) generateCredentials(ctx context.Context, user *topology
 	return credentials, nil
 }
 
-func (r *UserReconciler) importCredentials(ctx context.Context, secretName, secretNamespace string) (internal.UserCredentials, error) {
+func (r *UserReconciler) importCredentials(ctx context.Context, secretName, secretNamespace string) (internal.UserCredentials, string, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("Importing user credentials from provided Secret", "secretName", secretName, "secretNamespace", secretNamespace)
 
@@ -150,12 +152,12 @@ func (r *UserReconciler) importCredentials(ctx context.Context, secretName, secr
 
 	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &credentialsSecret)
 	if err != nil {
-		return credentials, fmt.Errorf("could not find password secret %s in namespace %s; Err: %w", secretName, secretNamespace, err)
+		return credentials, "", fmt.Errorf("could not find password secret %s in namespace %s; Err: %w", secretName, secretNamespace, err)
 	}
 
 	username, ok := credentialsSecret.Data["username"]
 	if !ok || len(username) == 0 {
-		return credentials, fmt.Errorf("could not find username key in credentials secret: %s", credentialsSecret.Name)
+		return credentials, "", fmt.Errorf("could not find username key in credentials secret: %s", credentialsSecret.Name)
 	}
 	credentials.Username = string(username)
 
@@ -169,10 +171,12 @@ func (r *UserReconciler) importCredentials(ctx context.Context, secretName, secr
 	}
 
 	logger.Info("Retrieved credentials from Secret", "secretName", secretName, "retrievedUsername", string(username))
-	return credentials, nil
+	return credentials, credentialsSecret.ResourceVersion, nil
 }
 
-func (r *UserReconciler) setUserStatus(ctx context.Context, user *topology.User, username, credentialsSecretName string) error {
+// setUserStatus persists the credentials reference, username, and the resourceVersion of the
+// credentials Secret that was just successfully applied to RabbitMQ.
+func (r *UserReconciler) setUserStatus(ctx context.Context, user *topology.User, username, credentialsSecretName, secretVersion string) error {
 	logger := ctrl.LoggerFrom(ctx)
 
 	credentials := &corev1.LocalObjectReference{
@@ -180,6 +184,7 @@ func (r *UserReconciler) setUserStatus(ctx context.Context, user *topology.User,
 	}
 	user.Status.Credentials = credentials
 	user.Status.Username = username
+	user.Status.ObservedSecretVersion = secretVersion
 	if err := r.Status().Update(ctx, user); err != nil {
 		msg := "Failed to update secret status credentials"
 		logger.Error(err, msg, "user", user.Name, "secretRef", credentials)
@@ -200,19 +205,16 @@ func (r *UserReconciler) DeclareFunc(ctx context.Context, rmqc rabbitmqclient.Cl
 func (r *UserReconciler) declareWithImportedCredentials(ctx context.Context, rmqc rabbitmqclient.Client, user *topology.User) error {
 	logger := ctrl.LoggerFrom(ctx)
 
-	credentials, err := r.importCredentials(ctx, user.Spec.ImportCredentialsSecret.Name, user.Namespace)
+	credentials, secretResourceVersion, err := r.importCredentials(ctx, user.Spec.ImportCredentialsSecret.Name, user.Namespace)
 	if err != nil {
 		return err
 	}
 
-	// Update status on first run, or correct a migration where Status.Credentials.Name
-	// still points to the old generated secret rather than the import secret.
-	if user.Status.Credentials == nil ||
-		user.Status.Credentials.Name != user.Spec.ImportCredentialsSecret.Name ||
-		user.Status.Username != credentials.Username {
-		if err := r.setUserStatus(ctx, user, credentials.Username, user.Spec.ImportCredentialsSecret.Name); err != nil {
-			return err
-		}
+	// Skip the RabbitMQ write entirely if neither the User spec nor the import secret have
+	// changed since the last successful sync — avoids re-issuing PutUser (and generating a
+	// fresh salted password hash) on every reconcile.
+	if user.Generation == user.Status.ObservedGeneration && secretResourceVersion == user.Status.ObservedSecretVersion {
+		return r.reconcileUserLimits(ctx, rmqc, user, credentials.Username)
 	}
 
 	userSettings, err := internal.GenerateUserSettings(credentials, user.Spec.Tags)
@@ -224,6 +226,12 @@ func (r *UserReconciler) declareWithImportedCredentials(ctx context.Context, rmq
 	if err := validateResponse(rmqc.PutUser(userSettings.Name, userSettings)); err != nil {
 		return err
 	}
+
+	user.SetStatusConditions([]topology.Condition{topology.PasswordSynced(user.Status.Conditions)})
+	if err := r.setUserStatus(ctx, user, credentials.Username, user.Spec.ImportCredentialsSecret.Name, secretResourceVersion); err != nil {
+		return err
+	}
+	r.Recorder.Eventf(user, nil, corev1.EventTypeNormal, "PasswordUpdated", updateEventAction, "synced password for user %q", user.Status.Username)
 
 	return r.reconcileUserLimits(ctx, rmqc, user, credentials.Username)
 }
@@ -253,11 +261,11 @@ func (r *UserReconciler) declareWithGeneratedCredentials(ctx context.Context, rm
 		actualUsername = username
 	}
 
-	if user.Status.Credentials == nil || user.Status.Username == "" ||
-		user.Status.Credentials.Name != user.Name+"-user-credentials" {
-		if err := r.setUserStatus(ctx, user, actualUsername, user.Name+"-user-credentials"); err != nil {
-			return err
-		}
+	// Skip the RabbitMQ write entirely if neither the User spec nor the generated credentials
+	// secret have changed since the last successful sync — avoids re-issuing PutUser (and
+	// generating a fresh salted password hash) on every reconcile.
+	if user.Generation == user.Status.ObservedGeneration && credentials.ResourceVersion == user.Status.ObservedSecretVersion {
+		return r.reconcileUserLimits(ctx, rmqc, user, actualUsername)
 	}
 
 	userSettings, err := internal.GenerateUserSettings(secretToCredentials(credentials), user.Spec.Tags)
@@ -269,6 +277,12 @@ func (r *UserReconciler) declareWithGeneratedCredentials(ctx context.Context, rm
 	if err := validateResponse(rmqc.PutUser(userSettings.Name, userSettings)); err != nil {
 		return err
 	}
+
+	user.SetStatusConditions([]topology.Condition{topology.PasswordSynced(user.Status.Conditions)})
+	if err := r.setUserStatus(ctx, user, actualUsername, user.Name+"-user-credentials", credentials.ResourceVersion); err != nil {
+		return err
+	}
+	r.Recorder.Eventf(user, nil, corev1.EventTypeNormal, "PasswordUpdated", updateEventAction, "synced password for user %q", user.Status.Username)
 
 	return r.reconcileUserLimits(ctx, rmqc, user, actualUsername)
 }

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("UserController", func() {
 			Scheme:                userMgr.GetScheme(),
 			Recorder:              fakeRecorder,
 			RabbitmqClientFactory: fakeRabbitMQClientFactory,
-			ReconcileFunc:         &controller.UserReconciler{Client: userMgr.GetClient(), Scheme: userMgr.GetScheme()},
+			ReconcileFunc:         &controller.UserReconciler{Client: userMgr.GetClient(), Scheme: userMgr.GetScheme(), Recorder: fakeRecorder},
 		}).SetupWithManager(userMgr)).To(Succeed())
 	}
 
@@ -627,6 +627,82 @@ var _ = Describe("UserController", func() {
 			latestIdx := fakeRabbitMQClient.PutUserCallCount() - 1
 			username, _ := fakeRabbitMQClient.PutUserArgsForCall(latestIdx)
 			Expect(username).To(Equal("imported-user"))
+
+			Eventually(objectStatus).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(
+				ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(topology.ConditionType("PasswordSynced")),
+					"Reason": Equal("SuccessfulPasswordSync"),
+					"Status": Equal(corev1.ConditionTrue),
+				})),
+			)
+			Eventually(observedEvents).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(
+				ContainElement(`Normal PasswordUpdated synced password for user "imported-user"`),
+			)
+		})
+
+		It("does not call PutUser again when a reconcile is triggered without any relevant change", func() {
+			Eventually(func() int {
+				return fakeRabbitMQClient.PutUserCallCount()
+			}).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(BeNumerically(">", 0))
+			callsBefore := fakeRabbitMQClient.PutUserCallCount()
+
+			// Trigger a reconcile via a metadata-only change on the User itself (annotations
+			// don't bump .metadata.generation), without touching the import secret at all.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &user)).To(Succeed())
+			if user.Annotations == nil {
+				user.Annotations = map[string]string{}
+			}
+			user.Annotations["unrelated"] = "churn"
+			Expect(k8sClient.Update(ctx, &user)).To(Succeed())
+
+			Consistently(func() int {
+				return fakeRabbitMQClient.PutUserCallCount()
+			}).Within(5 * time.Second).WithPolling(time.Second).Should(Equal(callsBefore))
+		})
+
+		It("still calls PutUser when only Tags change, with no secret change", func() {
+			Eventually(func() int {
+				return fakeRabbitMQClient.PutUserCallCount()
+			}).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(BeNumerically(">", 0))
+			callsBefore := fakeRabbitMQClient.PutUserCallCount()
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &user)).To(Succeed())
+			user.Spec.Tags = []topology.UserTag{"monitoring"}
+			Expect(k8sClient.Update(ctx, &user)).To(Succeed())
+
+			Eventually(func() int {
+				return fakeRabbitMQClient.PutUserCallCount()
+			}).Within(statusEventsUpdateTimeout).WithPolling(time.Second).
+				Should(BeNumerically(">", callsBefore))
+
+			latestIdx := fakeRabbitMQClient.PutUserCallCount() - 1
+			_, settings := fakeRabbitMQClient.PutUserArgsForCall(latestIdx)
+			Expect(settings.Tags).To(ConsistOf("monitoring"))
+		})
+
+		It("leaves Tags unchanged in the PutUser payload across a password-only rotation", func() {
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &user)).To(Succeed())
+			user.Spec.Tags = []topology.UserTag{"management"}
+			Expect(k8sClient.Update(ctx, &user)).To(Succeed())
+
+			Eventually(func() int {
+				return fakeRabbitMQClient.PutUserCallCount()
+			}).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(BeNumerically(">", 0))
+			callsBefore := fakeRabbitMQClient.PutUserCallCount()
+
+			importSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: importSecretName, Namespace: userNamespace}, importSecret)).To(Succeed())
+			importSecret.Data["password"] = []byte("another-rotated-password")
+			Expect(k8sClient.Update(ctx, importSecret)).To(Succeed())
+
+			Eventually(func() int {
+				return fakeRabbitMQClient.PutUserCallCount()
+			}).Within(statusEventsUpdateTimeout).WithPolling(time.Second).
+				Should(BeNumerically(">", callsBefore))
+
+			latestIdx := fakeRabbitMQClient.PutUserCallCount() - 1
+			_, settings := fakeRabbitMQClient.PutUserArgsForCall(latestIdx)
+			Expect(settings.Tags).To(ConsistOf("management"))
 		})
 	})
 
@@ -654,6 +730,40 @@ var _ = Describe("UserController", func() {
 		}).Within(10 * time.Second).WithPolling(time.Second).Should(
 			HaveKeyWithValue(topology.TopologyOperatorLabel, topology.TopologyOperatorLabelValue),
 		)
+	})
+
+	It("does not call PutUser again on a no-op reconcile of the generated credentials secret", func() {
+		userName = "test-generated-creds-idempotent"
+		initialiseUser()
+		user.Labels = map[string]string{"test": userName}
+		fakeRabbitMQClient.PutUserReturns(&http.Response{Status: "201 Created", StatusCode: http.StatusCreated}, nil)
+		initialiseManager("test", userName)
+
+		Expect(k8sClient.Create(ctx, &user)).To(Succeed())
+		Eventually(objectStatus).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(
+			ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(topology.ConditionType("Ready")),
+				"Reason": Equal("SuccessfulCreateOrUpdate"),
+				"Status": Equal(corev1.ConditionTrue),
+			})),
+		)
+		Eventually(func() int {
+			return fakeRabbitMQClient.PutUserCallCount()
+		}).Within(statusEventsUpdateTimeout).WithPolling(time.Second).Should(BeNumerically(">", 0))
+		callsBefore := fakeRabbitMQClient.PutUserCallCount()
+
+		// Trigger a reconcile via a metadata-only change on the User itself (annotations
+		// don't bump .metadata.generation), without touching the generated secret at all.
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, &user)).To(Succeed())
+		if user.Annotations == nil {
+			user.Annotations = map[string]string{}
+		}
+		user.Annotations["unrelated"] = "churn"
+		Expect(k8sClient.Update(ctx, &user)).To(Succeed())
+
+		Consistently(func() int {
+			return fakeRabbitMQClient.PutUserCallCount()
+		}).Within(5 * time.Second).WithPolling(time.Second).Should(Equal(callsBefore))
 	})
 
 	It("sets an owner reference and does not block owner deletion", func() {


### PR DESCRIPTION
## Summary

Closes RMQ-2841. Builds on RMQ-2838's label-gated Secret cache/import-secret watch.

Today, `UserReconciler.DeclareFunc` calls `PutUser` on every successful reconcile, and `internal.GenerateUserSettings` salts the password hash freshly each call — so RabbitMQ receives a real credential-changing write on every reconcile, even when the password hasn't changed.

- Track `UserStatus.ObservedSecretVersion` (the credentials Secret's `resourceVersion` last successfully applied) alongside the existing `ObservedGeneration`, and skip `PutUser` when neither has changed since the last successful sync.
- Add a `PasswordSynced` condition (upserted alongside `Ready` — `User.SetStatusConditions` now merges by condition type instead of overwriting the whole slice).
- Emit a `Normal PasswordUpdated` Kubernetes Event on real syncs, via a new `UserReconciler.Recorder`.
- Fix a stale `ImportCredentialsSecret` doc comment claiming import only happens at creation time (no longer true since RMQ-2838).

**Scope tradeoff (intentional):** periodic resyncs no longer correct password drift made directly against RabbitMQ (e.g. via `rabbitmqctl`) — only k8s-triggered changes (Secret rotation, Tags edits) now re-sync. This matches the ticket's AC1 wording ("reconciliation triggered by a Secret change").

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `make generate manifests` — CRD/deepcopy diff reviewed, contains only the new `observedSecretVersion` field and the updated doc comment
- [x] `make just-unit-tests` — all 8 suites pass
- [x] `make just-integration-tests` — full 94/94 controller specs pass (confirms the `SetStatusConditions` change is a no-op for the other 11 CRs)
- [x] New/extended tests in `internal/controller/user_controller_test.go`:
  - no-op reconcile (metadata-only User change) doesn't re-call `PutUser`, for both imported- and generated-credentials paths
  - Tags-only spec change still triggers `PutUser`
  - real password rotation sets `PasswordSynced: True`, emits `Normal PasswordUpdated`, and leaves `Tags` unchanged in the `PutUser` payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)