### PR TITLE
Remove CRD reference doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ kind: $(LOCALBIN) ## Download kind locally if necessary
 	$(LOCALBIN)/kind version
 
 .PHONY: install-tools
-install-tools: controller-gen envtest golangci-lint crd-ref-docs counterfeiter ginkgo-cli yj govulncheck openapi-gen ## Install all tooling required to configure and build this repo
+install-tools: controller-gen envtest golangci-lint counterfeiter ginkgo-cli yj govulncheck openapi-gen ## Install all tooling required to configure and build this repo
 	@echo "All tools installed successfully"
 
 ##@ Testing


### PR DESCRIPTION
## Summary
- Remove `crd-ref-docs` tool, `api-reference` Makefile target, and its dependency wiring (including the leftover reference in `install-tools`)
- Delete `.github/workflows/publish-versioned-api-ref.yml`, which generated and published the API reference to the wiki on release tags

## Test plan
- [x] `make install-tools` succeeds with no `crd-ref-docs` errors
- [x] `make unit-tests` passes (8 suites, 272 specs)
- [x] `make integration-tests` passes (94/94 specs)