### PR TITLE
Bypass cache for Service reads to avoid unbounded cluster-wide informer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -284,6 +284,16 @@ func main() {
 		}),
 	}
 
+	// rabbitmqclient.ParseReference reads the RabbitmqCluster's management Service by name on
+	// every reconcile. There is no label to scope a Service informer the way there is for
+	// Secret, and caching every Service across every namespace is not acceptable, so reads for
+	// this type bypass the cache entirely and go straight to the API server.
+	managerOpts.Client.Cache = &client.CacheOptions{
+		DisableFor: []client.Object{
+			&corev1.Service{},
+		},
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOpts)
 	if err != nil {
 		log.Error(err, "unable to start manager")


### PR DESCRIPTION
## Summary
- `rabbitmqclient.ParseReference` reads the RabbitmqCluster's management `Service` by name via the cached manager client on every reconcile. With no cache config for `corev1.Service` in `cmd/main.go`, the first such read silently creates a cluster-wide, unbounded Service informer/cache (same anti-pattern class as the pre-fix `Secret` memory-growth issue).
- Unlike `Secret`, there's no stable operator-owned label to scope a `Service` informer via `cache.ByObject`, and caching every Service across every namespace is not acceptable.
- Adds `corev1.Service` to `managerOpts.Client.Cache.DisableFor`, so reads for this type bypass the cache entirely and go straight to the API server instead of spinning up an informer.

## Test plan
- [x] `gmake unit-tests` — all 8 suites pass, including `Rabbitmqclient Suite` (70/70) which exercises `ParseReference`
- [x] `gmake integration-tests` — `Controller Suite` 95/95 specs pass against envtest (Shovel/Federation/SchemaReplication/User controllers all exercise this code path)
- [x] `go build ./...` / `go vet ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)