### PR TITLE
Exclude metrics-cert mount from OLM bundle deployment spec

### DIFF
--- a/olm/Makefile
+++ b/olm/Makefile
@@ -48,7 +48,14 @@ deployment: $(TMP_DIR)/_all_manifests.yaml $(TMP_DIR) $(OLM_MANIFEST_DIR) ## Ext
 			--data-value operator_image=$(QUAY_IO_OPERATOR_IMAGE) \
 			-f $(REPO_ROOT)/olm/bundle/templates/topology-operator-namespace-scope-overlay.yml \
 		> $(TMP_DIR)/topology-operator.yml
-	yq 'select(.kind =="Deployment") | {"spec": .spec}' $(TMP_DIR)/topology-operator.yml > $(TMP_DIR)/spec.yaml
+	# Unlike the webhook cert, OLM has no built-in mechanism to provision the cert-manager-issued
+	# "metrics-server-cert" secret, so strip that mount here and let the manager fall back to its
+	# self-signed in-memory metrics cert under OLM installs (still served over HTTPS).
+	yq "select(.kind ==\"Deployment\") | \
+		del(.spec.template.spec.volumes[] | select(.name == \"metrics-certs\")) | \
+		del(.spec.template.spec.containers[0].volumeMounts[] | select(.name == \"metrics-certs\")) | \
+		del(.spec.template.spec.containers[0].args[] | select(test(\"^--metrics-cert-path=\"))) | \
+		{\"spec\": .spec}" $(TMP_DIR)/topology-operator.yml > $(TMP_DIR)/spec.yaml
 
 webhooks: $(TMP_DIR)/_all_manifests.yaml $(TMP_DIR) ## Extract Web-hook manifests into a temporary file
 	yq 'select(.kind =="ValidatingWebhookConfiguration") | {"webhooks": .webhooks}' $(TMP_DIR)/_all_manifests.yaml \


### PR DESCRIPTION
## Summary
- The v1.20.0/v1.20.1 OLM bundle tests fail because the operator pod never starts: it hangs forever in `ContainerCreating` waiting to mount a `metrics-certs` volume backed by the cert-manager-issued `metrics-server-cert` secret (`optional: false`).
- That volume was unconditionally added to the manager Deployment by 59450dd ("Mount cert-manager cert for serving metrics"). Unlike the webhook cert, OLM has no built-in mechanism to provision this secret (it isn't tied to any `webhookdefinitions`/`apiservicedefinitions` entry in the CSV), and the OLM bundle-generation Makefile only extracts the raw Deployment spec, dropping the `Certificate`/`Issuer` resources that would normally create it.
- `olm/Makefile`'s `deployment` target now strips the `metrics-certs` volume, its volumeMount, and the `--metrics-cert-path` arg before extracting the Deployment spec for the CSV. `--metrics-secure` stays, so the manager falls back to controller-runtime's self-signed in-memory metrics cert under OLM installs — the same behavior OLM installs had before v1.20.0. The regular kustomize/cert-manager deploy path (`config/default`, `make deploy`) is untouched.

## Test plan
- [x] Reproduced the failure locally: applied the CSV's (pre-fix) Deployment spec to a clean namespace in a local k3s+OLM cluster and confirmed the pod hangs in `ContainerCreating` with `MountVolume.SetUp failed ... secret "metrics-server-cert" not found`, matching the CI failure.
- [x] Regenerated the CSV with the fix and confirmed `metrics-certs` volume/volumeMount/arg are gone while `--metrics-secure` and the webhook `cert` volume are untouched.
- [x] Applied the fixed Deployment spec to a clean namespace and confirmed the pod reaches `1/1 Running` with no `FailedMount` events.
- [ ] CI: `Test & Publish OLM bundle` workflow passes on this branch/next release.