### PR TITLE
Use NS in connection secret if present

### DIFF
--- a/api/v1beta1/rabbitmq_cluster_reference.go
+++ b/api/v1beta1/rabbitmq_cluster_reference.go
@@ -54,6 +54,15 @@ func (r *RabbitmqClusterReference) ValidateOnCreate(_ schema.GroupResource, _ st
 	return nil, r.validate(*r)
 }
 
+// ConnectionSecretNamespace returns the namespace in which ConnectionSecret should be looked
+// up: Namespace when set, otherwise the referencing resource's own namespace.
+func (r *RabbitmqClusterReference) ConnectionSecretNamespace(resourceNamespace string) string {
+	if r.Namespace == "" {
+		return resourceNamespace
+	}
+	return r.Namespace
+}
+
 func (r *RabbitmqClusterReference) validate(ref RabbitmqClusterReference) error {
 	if ref.Name != "" && ref.ConnectionSecret != nil {
 		return errors.New("invalid RabbitmqClusterReference: do not provide both name and connectionSecret")

--- a/api/v1beta1/rabbitmq_cluster_reference_test.go
+++ b/api/v1beta1/rabbitmq_cluster_reference_test.go
@@ -108,4 +108,20 @@ var _ = Describe("RabbitmqClusterReference", func() {
 		})
 	})
 
+	Context("ConnectionSecretNamespace", func() {
+		When("Namespace is set on the reference", func() {
+			It("returns the reference's namespace", func() {
+				reference.Namespace = "referenced-ns"
+				Expect(reference.ConnectionSecretNamespace("resource-ns")).To(Equal("referenced-ns"))
+			})
+		})
+
+		When("Namespace is not set on the reference", func() {
+			It("returns the resource's own namespace", func() {
+				reference.Namespace = ""
+				Expect(reference.ConnectionSecretNamespace("resource-ns")).To(Equal("resource-ns"))
+			})
+		})
+	})
+
 })

--- a/internal/webhook/v1beta1/binding_webhook.go
+++ b/internal/webhook/v1beta1/binding_webhook.go
@@ -54,7 +54,8 @@ type BindingCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Binding.
 // either rabbitmqClusterReference.name or rabbitmqClusterReference.connectionSecret must be provided but not both
 func (v *BindingCustomValidator) ValidateCreate(ctx context.Context, obj *rabbitmqcomv1beta1.Binding) (admission.Warnings, error) {
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, obj.Namespace); err != nil {
+	connSecretNS := obj.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(obj.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return obj.Spec.RabbitmqClusterReference.ValidateOnCreate(obj.GroupResource(), obj.Name)

--- a/internal/webhook/v1beta1/exchange_webhook.go
+++ b/internal/webhook/v1beta1/exchange_webhook.go
@@ -33,7 +33,8 @@ func SetupExchangeWebhookWithManager(mgr ctrl.Manager) error {
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 // either rabbitmqClusterReference.name or rabbitmqClusterReference.connectionSecret must be provided but not both
 func (v *ExchangeCustomValidator) ValidateCreate(ctx context.Context, ex *rabbitmqcomv1beta1.Exchange) (warnings admission.Warnings, err error) {
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, ex.Spec.RabbitmqClusterReference.ConnectionSecret, ex.Namespace); err != nil {
+	connSecretNS := ex.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(ex.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, ex.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return ex.Spec.RabbitmqClusterReference.ValidateOnCreate(ex.GroupResource(), ex.Name)

--- a/internal/webhook/v1beta1/federation_webhook.go
+++ b/internal/webhook/v1beta1/federation_webhook.go
@@ -35,7 +35,8 @@ func (v *FederationCustomValidator) ValidateCreate(ctx context.Context, fed *rab
 	if err := validateSecretLabel(ctx, v.Client, v.APIReader, fed.Spec.UriSecret, fed.Namespace); err != nil {
 		return nil, err
 	}
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, fed.Spec.RabbitmqClusterReference.ConnectionSecret, fed.Namespace); err != nil {
+	connSecretNS := fed.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(fed.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, fed.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return fed.Spec.RabbitmqClusterReference.ValidateOnCreate(fed.GroupResource(), fed.Name)

--- a/internal/webhook/v1beta1/operatorpolicy_webhook.go
+++ b/internal/webhook/v1beta1/operatorpolicy_webhook.go
@@ -52,7 +52,8 @@ type OperatorPolicyCustomValidator struct {
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type OperatorPolicy.
 func (v *OperatorPolicyCustomValidator) ValidateCreate(ctx context.Context, obj *rabbitmqcomv1beta1.OperatorPolicy) (admission.Warnings, error) {
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, obj.Namespace); err != nil {
+	connSecretNS := obj.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(obj.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return obj.Spec.RabbitmqClusterReference.ValidateOnCreate(obj.GroupResource(), obj.Name)

--- a/internal/webhook/v1beta1/permission_webhook.go
+++ b/internal/webhook/v1beta1/permission_webhook.go
@@ -63,7 +63,8 @@ func (v *PermissionCustomValidator) ValidateCreate(ctx context.Context, obj *rab
 			"cannot specify spec.user and spec.userReference at the same time")
 	}
 
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, obj.Namespace); err != nil {
+	connSecretNS := obj.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(obj.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1beta1/policy_webhook.go
+++ b/internal/webhook/v1beta1/policy_webhook.go
@@ -32,7 +32,8 @@ func SetupPolicyWebhookWithManager(mgr ctrl.Manager) error {
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 // either rabbitmqClusterReference.name or rabbitmqClusterReference.connectionSecret must be provided but not both
 func (v *PolicyCustomValidator) ValidateCreate(ctx context.Context, policy *rabbitmqcomv1beta1.Policy) (warnings admission.Warnings, err error) {
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, policy.Spec.RabbitmqClusterReference.ConnectionSecret, policy.Namespace); err != nil {
+	connSecretNS := policy.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(policy.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, policy.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return policy.Spec.RabbitmqClusterReference.ValidateOnCreate(policy.GroupResource(), policy.Name)

--- a/internal/webhook/v1beta1/queue_webhook.go
+++ b/internal/webhook/v1beta1/queue_webhook.go
@@ -42,7 +42,8 @@ func (v *QueueCustomValidator) ValidateCreate(ctx context.Context, inQueue *rabb
 			field.Forbidden(field.NewPath("spec", "durable"),
 				"Quorum queues must have durable set to true"))
 	}
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, inQueue.Spec.RabbitmqClusterReference.ConnectionSecret, inQueue.Namespace); err != nil {
+	connSecretNS := inQueue.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(inQueue.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, inQueue.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return inQueue.Spec.RabbitmqClusterReference.ValidateOnCreate(inQueue.GroupResource(), inQueue.Name)

--- a/internal/webhook/v1beta1/schemareplication_webhook.go
+++ b/internal/webhook/v1beta1/schemareplication_webhook.go
@@ -61,7 +61,8 @@ func (v *SchemaReplicationCustomValidator) ValidateCreate(ctx context.Context, o
 		return nil, err
 	}
 
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, obj.Namespace); err != nil {
+	connSecretNS := obj.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(obj.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1beta1/shovel_webhook.go
+++ b/internal/webhook/v1beta1/shovel_webhook.go
@@ -62,7 +62,8 @@ func (v *ShovelCustomValidator) ValidateCreate(ctx context.Context, obj *rabbitm
 		return nil, err
 	}
 
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, obj.Namespace); err != nil {
+	connSecretNS := obj.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(obj.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1beta1/topicpermission_webhook.go
+++ b/internal/webhook/v1beta1/topicpermission_webhook.go
@@ -57,7 +57,8 @@ func (v *TopicPermissionCustomValidator) ValidateCreate(ctx context.Context, obj
 		return nil, field.Required(field.NewPath("spec", "user and userReference"),
 			"cannot specify spec.user and spec.userReference at the same time")
 	}
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, obj.Namespace); err != nil {
+	connSecretNS := obj.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(obj.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, obj.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return obj.Spec.RabbitmqClusterReference.ValidateOnCreate(obj.GroupResource(), obj.Name)

--- a/internal/webhook/v1beta1/user_webhook.go
+++ b/internal/webhook/v1beta1/user_webhook.go
@@ -35,7 +35,8 @@ func (v *UserCustomValidator) ValidateCreate(ctx context.Context, user *rabbitmq
 	if err := validateSecretLabel(ctx, v.Client, v.APIReader, user.Spec.ImportCredentialsSecret, user.Namespace); err != nil {
 		return nil, err
 	}
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, user.Spec.RabbitmqClusterReference.ConnectionSecret, user.Namespace); err != nil {
+	connSecretNS := user.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(user.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, user.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return user.Spec.RabbitmqClusterReference.ValidateOnCreate(user.GroupResource(), user.Name)

--- a/internal/webhook/v1beta1/user_webhook_test.go
+++ b/internal/webhook/v1beta1/user_webhook_test.go
@@ -212,4 +212,82 @@ var _ = Describe("User Webhook", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	Context("connectionSecret label enforcement respects rabbitmqClusterReference.namespace", func() {
+		const (
+			resourceNS   = "default"
+			referencedNS = "other-ns"
+		)
+
+		buildUserWithConnectionSecret := func(refNamespace, secretName string) *rabbitmqcomv1beta1.User {
+			return &rabbitmqcomv1beta1.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-user", Namespace: resourceNS},
+				Spec: rabbitmqcomv1beta1.UserSpec{
+					RabbitmqClusterReference: rabbitmqcomv1beta1.RabbitmqClusterReference{
+						Namespace:        refNamespace,
+						ConnectionSecret: &corev1.LocalObjectReference{Name: secretName},
+					},
+				},
+			}
+		}
+
+		When("rabbitmqClusterReference.namespace is set", func() {
+			When("the connectionSecret exists in that namespace", func() {
+				It("allows creation", func() {
+					labeledSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "conn-secret",
+							Namespace: referencedNS,
+							Labels: map[string]string{
+								rabbitmqcomv1beta1.TopologyOperatorLabel: rabbitmqcomv1beta1.TopologyOperatorLabelValue,
+							},
+						},
+					}
+					cacheClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(labeledSecret).Build()
+					v := UserCustomValidator{Client: cacheClient, APIReader: cacheClient}
+
+					_, err := v.ValidateCreate(ctx, buildUserWithConnectionSecret(referencedNS, "conn-secret"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("the connectionSecret only exists in the resource's own namespace", func() {
+				It("denies creation", func() {
+					secretInWrongNamespace := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "conn-secret",
+							Namespace: resourceNS,
+							Labels: map[string]string{
+								rabbitmqcomv1beta1.TopologyOperatorLabel: rabbitmqcomv1beta1.TopologyOperatorLabelValue,
+							},
+						},
+					}
+					cacheClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secretInWrongNamespace).Build()
+					v := UserCustomValidator{Client: cacheClient, APIReader: cacheClient}
+
+					_, err := v.ValidateCreate(ctx, buildUserWithConnectionSecret(referencedNS, "conn-secret"))
+					Expect(err).To(MatchError(ContainSubstring("not found")))
+				})
+			})
+		})
+
+		When("rabbitmqClusterReference.namespace is unset", func() {
+			It("falls back to looking up the connectionSecret in the resource's own namespace", func() {
+				labeledSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "conn-secret",
+						Namespace: resourceNS,
+						Labels: map[string]string{
+							rabbitmqcomv1beta1.TopologyOperatorLabel: rabbitmqcomv1beta1.TopologyOperatorLabelValue,
+						},
+					},
+				}
+				cacheClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(labeledSecret).Build()
+				v := UserCustomValidator{Client: cacheClient, APIReader: cacheClient}
+
+				_, err := v.ValidateCreate(ctx, buildUserWithConnectionSecret("", "conn-secret"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
 })

--- a/internal/webhook/v1beta1/vhost_webhook.go
+++ b/internal/webhook/v1beta1/vhost_webhook.go
@@ -34,7 +34,8 @@ func SetupVhostWebhookWithManager(mgr ctrl.Manager) error {
 // Either rabbitmqClusterReference.name or
 // rabbitmqClusterReference.connectionSecret must be provided but not both
 func (v *VhostCustomValidator) ValidateCreate(ctx context.Context, vhost *rabbitmqcomv1beta1.Vhost) (warnings admission.Warnings, err error) {
-	if err := validateSecretLabel(ctx, v.Client, v.APIReader, vhost.Spec.RabbitmqClusterReference.ConnectionSecret, vhost.Namespace); err != nil {
+	connSecretNS := vhost.Spec.RabbitmqClusterReference.ConnectionSecretNamespace(vhost.Namespace)
+	if err := validateSecretLabel(ctx, v.Client, v.APIReader, vhost.Spec.RabbitmqClusterReference.ConnectionSecret, connSecretNS); err != nil {
 		return nil, err
 	}
 	return vhost.Spec.RabbitmqClusterReference.ValidateOnCreate(vhost.GroupResource(), vhost.Name)

--- a/internal/webhook/v1beta1/vhost_webhook_test.go
+++ b/internal/webhook/v1beta1/vhost_webhook_test.go
@@ -21,7 +21,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	rabbitmqcomv1beta1 "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
-	// TODO (user): Add any additional imports if needed
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Vhost Webhook", func() {
@@ -35,36 +38,132 @@ var _ = Describe("Vhost Webhook", func() {
 		obj = &rabbitmqcomv1beta1.Vhost{}
 		oldObj = &rabbitmqcomv1beta1.Vhost{}
 		validator = VhostCustomValidator{}
-		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
-		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
-		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
 	})
 
-	AfterEach(func() {
-		// TODO (user): Add any teardown logic common to all tests
+	Context("structural validation (no k8s client needed)", func() {
+		It("allows creation when only a cluster name is provided", func() {
+			obj = &rabbitmqcomv1beta1.Vhost{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vhost", Namespace: "default"},
+				Spec: rabbitmqcomv1beta1.VhostSpec{
+					Name: "test-vhost",
+					RabbitmqClusterReference: rabbitmqcomv1beta1.RabbitmqClusterReference{
+						Name: "my-cluster",
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("denies creation when both cluster name and connectionSecret are provided", func() {
+			obj = &rabbitmqcomv1beta1.Vhost{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vhost", Namespace: "default"},
+				Spec: rabbitmqcomv1beta1.VhostSpec{
+					Name: "test-vhost",
+					RabbitmqClusterReference: rabbitmqcomv1beta1.RabbitmqClusterReference{
+						Name:             "my-cluster",
+						ConnectionSecret: &corev1.LocalObjectReference{Name: "conn-secret"},
+					},
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("denies updates to rabbitmqClusterReference", func() {
+			oldObj = &rabbitmqcomv1beta1.Vhost{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vhost", Namespace: "default"},
+				Spec: rabbitmqcomv1beta1.VhostSpec{
+					Name: "test-vhost",
+					RabbitmqClusterReference: rabbitmqcomv1beta1.RabbitmqClusterReference{
+						Name: "my-cluster",
+					},
+				},
+			}
+			obj = oldObj.DeepCopy()
+			obj.Spec.RabbitmqClusterReference.Name = "other-cluster"
+
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
-	Context("When creating or updating Vhost under Validating Webhook", func() {
-		// TODO (user): Add logic for validating webhooks
-		// Example:
-		// It("Should deny creation if a required field is missing", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = ""
-		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
-		// })
-		//
-		// It("Should admit creation if all required fields are present", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = "valid_value"
-		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
-		// })
-		//
-		// It("Should validate updates correctly", func() {
-		//     By("simulating a valid update scenario")
-		//     oldObj.SomeRequiredField = "updated_value"
-		//     obj.SomeRequiredField = "updated_value"
-		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
-		// })
-	})
+	Context("connectionSecret label enforcement respects rabbitmqClusterReference.namespace", func() {
+		const (
+			resourceNS   = "default"
+			referencedNS = "other-ns"
+		)
 
+		buildVhostWithConnectionSecret := func(refNamespace, secretName string) *rabbitmqcomv1beta1.Vhost {
+			return &rabbitmqcomv1beta1.Vhost{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vhost", Namespace: resourceNS},
+				Spec: rabbitmqcomv1beta1.VhostSpec{
+					Name: "test-vhost",
+					RabbitmqClusterReference: rabbitmqcomv1beta1.RabbitmqClusterReference{
+						Namespace:        refNamespace,
+						ConnectionSecret: &corev1.LocalObjectReference{Name: secretName},
+					},
+				},
+			}
+		}
+
+		When("rabbitmqClusterReference.namespace is set", func() {
+			When("the connectionSecret exists in that namespace", func() {
+				It("allows creation", func() {
+					labeledSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "conn-secret",
+							Namespace: referencedNS,
+							Labels: map[string]string{
+								rabbitmqcomv1beta1.TopologyOperatorLabel: rabbitmqcomv1beta1.TopologyOperatorLabelValue,
+							},
+						},
+					}
+					cacheClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(labeledSecret).Build()
+					v := VhostCustomValidator{Client: cacheClient, APIReader: cacheClient}
+
+					_, err := v.ValidateCreate(ctx, buildVhostWithConnectionSecret(referencedNS, "conn-secret"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("the connectionSecret only exists in the resource's own namespace", func() {
+				It("denies creation", func() {
+					secretInWrongNamespace := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "conn-secret",
+							Namespace: resourceNS,
+							Labels: map[string]string{
+								rabbitmqcomv1beta1.TopologyOperatorLabel: rabbitmqcomv1beta1.TopologyOperatorLabelValue,
+							},
+						},
+					}
+					cacheClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secretInWrongNamespace).Build()
+					v := VhostCustomValidator{Client: cacheClient, APIReader: cacheClient}
+
+					_, err := v.ValidateCreate(ctx, buildVhostWithConnectionSecret(referencedNS, "conn-secret"))
+					Expect(err).To(MatchError(ContainSubstring("not found")))
+				})
+			})
+		})
+
+		When("rabbitmqClusterReference.namespace is unset", func() {
+			It("falls back to looking up the connectionSecret in the resource's own namespace", func() {
+				labeledSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "conn-secret",
+						Namespace: resourceNS,
+						Labels: map[string]string{
+							rabbitmqcomv1beta1.TopologyOperatorLabel: rabbitmqcomv1beta1.TopologyOperatorLabelValue,
+						},
+					},
+				}
+				cacheClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(labeledSecret).Build()
+				v := VhostCustomValidator{Client: cacheClient, APIReader: cacheClient}
+
+				_, err := v.ValidateCreate(ctx, buildVhostWithConnectionSecret("", "conn-secret"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
The connectionSecret field can reference Secrets in other namespaces. In that case, the webhook should check that the referenced Secret has the required label. Intentionally, it does not perform cross-ns allowance check. That remains solely in the reconcile loop. The motivation is to keep the webhook checks lean and fast. Cross-ns allowance check involves querying the API server and get information about a `rabbitmqCluster` object.

This closes #1244 